### PR TITLE
Type inference bug fix

### DIFF
--- a/cli/src/Morphir/Elm/CLI.elm
+++ b/cli/src/Morphir/Elm/CLI.elm
@@ -88,7 +88,7 @@ update msg model =
                                             thisPackageSpec : Package.Specification ()
                                             thisPackageSpec =
                                                 packageDef
-                                                    |> Package.definitionToSpecification
+                                                    |> Package.definitionToSpecificationWithPrivate
                                                     |> Package.mapSpecificationAttributes (\_ -> ())
 
                                             references : MetaTypeMapping.References

--- a/src/Morphir/IR/Package.elm
+++ b/src/Morphir/IR/Package.elm
@@ -19,7 +19,7 @@ module Morphir.IR.Package exposing
     ( Specification, emptySpecification
     , Definition, emptyDefinition
     , lookupModuleSpecification, lookupTypeSpecification, lookupValueSpecification
-    , PackageName, definitionToSpecification, eraseDefinitionAttributes, eraseSpecificationAttributes
+    , PackageName, definitionToSpecification, definitionToSpecificationWithPrivate, eraseDefinitionAttributes, eraseSpecificationAttributes
     , mapDefinitionAttributes, mapSpecificationAttributes
     )
 
@@ -46,13 +46,13 @@ including implementation and private types and values.
 
 # Other utilities
 
-@docs PackageName, definitionToSpecification, eraseDefinitionAttributes, eraseSpecificationAttributes
+@docs PackageName, definitionToSpecification, definitionToSpecificationWithPrivate, eraseDefinitionAttributes, eraseSpecificationAttributes
 @docs mapDefinitionAttributes, mapSpecificationAttributes
 
 -}
 
 import Dict exposing (Dict)
-import Morphir.IR.AccessControlled exposing (AccessControlled, withPublicAccess)
+import Morphir.IR.AccessControlled exposing (AccessControlled, withPrivateAccess, withPublicAccess)
 import Morphir.IR.Module as Module exposing (ModuleName)
 import Morphir.IR.Name exposing (Name)
 import Morphir.IR.Path exposing (Path)
@@ -142,6 +142,27 @@ definitionToSpecification def =
                             (\moduleDef ->
                                 ( path, Module.definitionToSpecification moduleDef )
                             )
+                )
+            |> Dict.fromList
+    }
+
+
+{-| Turn a package definition into a package specification. Non-exposed modules will also be included in the
+result.
+-}
+definitionToSpecificationWithPrivate : Definition ta va -> Specification ta
+definitionToSpecificationWithPrivate def =
+    { modules =
+        def.modules
+            |> Dict.toList
+            |> List.map
+                (\( path, accessControlledModule ) ->
+                    ( path
+                    , Module.definitionToSpecification
+                        (accessControlledModule
+                            |> withPrivateAccess
+                        )
+                    )
                 )
             |> Dict.fromList
     }

--- a/tests-integration/reference-model/morphir.json
+++ b/tests-integration/reference-model/morphir.json
@@ -6,6 +6,6 @@
         "Types",
         "Values",
         "Issues.Issue210",
-        "Visual"
+        "Issues.Issue227"
     ]
 }

--- a/tests-integration/reference-model/src/Morphir/Reference/Model/Issues/Common.elm
+++ b/tests-integration/reference-model/src/Morphir/Reference/Model/Issues/Common.elm
@@ -1,0 +1,5 @@
+module Morphir.Reference.Model.Issues.Common exposing (..)
+
+
+type alias FloatAlias =
+    Float

--- a/tests-integration/reference-model/src/Morphir/Reference/Model/Issues/Issue227.elm
+++ b/tests-integration/reference-model/src/Morphir/Reference/Model/Issues/Issue227.elm
@@ -1,0 +1,14 @@
+module Morphir.Reference.Model.Issues.Issue227 exposing (..)
+
+
+type alias FloatAlias =
+    Float
+
+
+fun : FloatAlias -> FloatAlias
+fun f =
+    if f <= 3.14 then
+        f
+
+    else
+        f

--- a/tests-integration/reference-model/src/Morphir/Reference/Model/Issues/Issue227.elm
+++ b/tests-integration/reference-model/src/Morphir/Reference/Model/Issues/Issue227.elm
@@ -1,8 +1,6 @@
 module Morphir.Reference.Model.Issues.Issue227 exposing (..)
 
-
-type alias FloatAlias =
-    Float
+import Morphir.Reference.Model.Issues.Common exposing (FloatAlias)
 
 
 fun : FloatAlias -> FloatAlias


### PR DESCRIPTION
closes #227 

# Terms

> THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE TERMS OF THE CCLA DATED 2017-11-07 WITH FINOS/LINUX FOUNDATION (FORMERLY THE SYMPHONY SOFTWARE FOUNDATION CCLA).
>
> THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
