### PR TITLE
Scala gen fixes

### DIFF
--- a/tests-integration/reference-model/morphir.json
+++ b/tests-integration/reference-model/morphir.json
@@ -8,6 +8,7 @@
         "Formulas",
         "Issues.Issue210",
         "Issues.Issue227",
-        "Issues.Issue273"
+        "Issues.Issue273",
+        "Issues.Issue330"
     ]
 }

--- a/tests-integration/reference-model/morphir.json
+++ b/tests-integration/reference-model/morphir.json
@@ -9,6 +9,7 @@
         "Issues.Issue210",
         "Issues.Issue227",
         "Issues.Issue273",
-        "Issues.Issue330"
+        "Issues.Issue330",
+        "Issues.Issue331"
     ]
 }

--- a/tests-integration/reference-model/src/Morphir/Reference/Model/Issues/Issue330.elm
+++ b/tests-integration/reference-model/src/Morphir/Reference/Model/Issues/Issue330.elm
@@ -1,0 +1,15 @@
+module Morphir.Reference.Model.Issues.Issue330 exposing (..)
+
+
+type MyType
+    = MyType String
+
+
+toString : MyType -> String
+toString (MyType v) =
+    v
+
+
+bar : String
+bar =
+    toString (MyType "bar")

--- a/tests-integration/reference-model/src/Morphir/Reference/Model/Issues/Issue331.elm
+++ b/tests-integration/reference-model/src/Morphir/Reference/Model/Issues/Issue331.elm
@@ -1,0 +1,10 @@
+module Morphir.Reference.Model.Issues.Issue331 exposing (..)
+
+
+type MyType
+    = MyType String String
+
+
+foo : List String -> List MyType
+foo list =
+    List.map2 MyType list list


### PR DESCRIPTION
closes #330, #331 

# Terms

> THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE TERMS OF THE CCLA DATED 2017-11-07 WITH FINOS/LINUX FOUNDATION (FORMERLY THE SYMPHONY SOFTWARE FOUNDATION CCLA).
>
> THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
