### PR TITLE
Convert Morphir.IR types to TypeScript as part of `gulp test`

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -77,6 +77,22 @@ const build =
     )
 
 
+function morphirElmMake(projectDir, outputPath, options) {
+    args = [ './cli/morphir-elm.js', 'make', '-p', projectDir, '-o', outputPath ]
+    if (options.typesOnly) {
+        args.push('--types-only')
+    }
+    console.log("Running: " + args.join(' '));
+    return execa('node', args, { stdio })
+}
+
+function morphirElmGen(inputPath, outputDir, target) {
+    args = [ './cli/morphir-elm.js', 'gen', '-i', inputPath, '-o', outputDir, '-t', target ]
+    console.log("Running: " + args.join(' '));
+    return execa('node', args, { stdio })
+}
+
+
 async function testUnit(cb) {
     await execa('elm-test');
 }
@@ -88,16 +104,11 @@ function testIntegrationClean() {
     ])
 }
 
+
 async function testIntegrationMake(cb) {
-    await execa(
-        'node',
-        [
-            './cli/morphir-elm.js', 'make',
-             '-p', './tests-integration/reference-model',
-             '-o', './tests-integration/generated/morphir-ir.json'
-        ],
-        { stdio },
-    )
+    await morphirElmMake(
+        './tests-integration/reference-model',
+        './tests-integration/generated/morphir-ir.json')
 }
 
 async function testIntegrationMorphirTest(cb) {
@@ -111,16 +122,10 @@ async function testIntegrationMorphirTest(cb) {
 }
 
 async function testIntegrationGenScala(cb) {
-    await execa(
-        'node',
-        [
-            './cli/morphir-elm.js', 'gen',
-            '-i', './tests-integration/generated/morphir-ir.json',
-            '-o', './tests-integration/generated/refModel/src/scala/',
-            '-t', 'Scala'
-        ],
-        { stdio },
-    )
+    await morphirElmGen(
+        './tests-integration/generated/morphir-ir.json',
+        './tests-integration/generated/refModel/src/scala/',
+        'Scala')
 }
 
 async function testIntegrationBuildScala(cb) {
@@ -139,16 +144,10 @@ async function testIntegrationBuildScala(cb) {
 }
 
 async function testIntegrationGenTypeScript(cb) {
-    await execa(
-        'node',
-        [
-            './cli/morphir-elm.js', 'gen',
-            '-i', './tests-integration/generated/morphir-ir.json',
-            '-o', './tests-integration/generated/refModel/src/typescript/',
-            '-t', 'TypeScript'
-        ],
-        { stdio },
-    )
+    await morphirElmGen(
+        './tests-integration/generated/morphir-ir.json',
+        './tests-integration/generated/refModel/src/typescript/',
+        'TypeScript')
 }
 
 function testIntegrationBuildTypeScript(cb) {


### PR DESCRIPTION
This is the first goal of #503, so let's include it in the testsuite.

# Terms

> THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE TERMS OF THE CCLA DATED 2017-11-07 WITH FINOS/LINUX FOUNDATION (FORMERLY THE SYMPHONY SOFTWARE FOUNDATION CCLA).
>
> THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
