### PR TITLE
Support parsing a single Elm expression, eliminate the need for type signatures

### DIFF
--- a/src/Morphir/Elm/Frontend.elm
+++ b/src/Morphir/Elm/Frontend.elm
@@ -20,6 +20,7 @@ module Morphir.Elm.Frontend exposing
     , defaultDependencies
     , Options, ContentLocation, ContentRange, Error(..), Errors, PackageInfo, SourceFile, SourceLocation, mapSource
     , mapValueToFile
+    , parseRawValue
     )
 
 {-| The Elm frontend turns Elm source code into Morphir IR.
@@ -36,6 +37,7 @@ module Morphir.Elm.Frontend exposing
 
 @docs Options, ContentLocation, ContentRange, Error, Errors, PackageInfo, SourceFile, SourceLocation, mapSource
 @docs mapValueToFile
+@docs parseRawValue
 
 -}
 
@@ -64,7 +66,7 @@ import Morphir.IR as IR exposing (IR)
 import Morphir.IR.AccessControlled exposing (AccessControlled, private, public)
 import Morphir.IR.Distribution exposing (Distribution(..))
 import Morphir.IR.Documented exposing (Documented)
-import Morphir.IR.FQName as FQName exposing (FQName, fQName)
+import Morphir.IR.FQName as FQName exposing (FQName, fQName, fqn)
 import Morphir.IR.Literal exposing (Literal(..))
 import Morphir.IR.Module as Module
 import Morphir.IR.Name as Name exposing (Name)
@@ -76,9 +78,10 @@ import Morphir.IR.SDK.Basics as SDKBasics
 import Morphir.IR.SDK.List as List
 import Morphir.IR.Type as Type exposing (Type)
 import Morphir.IR.Type.Rewrite exposing (rewriteType)
-import Morphir.IR.Value as Value exposing (Value)
+import Morphir.IR.Value as Value exposing (RawValue, Value)
 import Morphir.ListOfResults as ListOfResults
 import Morphir.Rewrite as Rewrite
+import Morphir.Type.Infer as Infer
 import Parser exposing (DeadEnd)
 import Set exposing (Set)
 
@@ -156,6 +159,7 @@ type Error
     | VariableShadowing Name SourceLocation SourceLocation
     | MissingTypeSignature SourceLocation
     | RecordPatternNotSupported SourceLocation
+    | TypeInferenceError SourceLocation Infer.TypeError
 
 
 type alias Imports =
@@ -178,6 +182,63 @@ defaultDependencies =
     Dict.fromList
         [ ( SDK.packageName, SDK.packageSpec )
         ]
+
+
+{-| Parses an expression written in the Elm syntax into a RawValue.
+-}
+parseRawValue : IR -> String -> Result String RawValue
+parseRawValue ir valueSourceCode =
+    let
+        dummyPackageName : Path
+        dummyPackageName =
+            Path.fromString "Morphir.Elm.Frontend"
+
+        dummyModuleName : Path
+        dummyModuleName =
+            Path.fromString "ParseValue"
+
+        dummyValueName : Name
+        dummyValueName =
+            Name.fromString "morphirElmFrontendParseValue"
+
+        dummyModuleSource : String
+        dummyModuleSource =
+            String.join "\n"
+                [ "module " ++ Path.toString Name.toTitleCase "." (dummyPackageName ++ dummyModuleName) ++ " exposing (..)"
+                , ""
+                , Name.toCamelCase dummyValueName ++ " = " ++ valueSourceCode
+                ]
+
+        dummyModule =
+            { path = Path.toString Name.toTitleCase "/" dummyModuleName ++ ".elm"
+            , content = dummyModuleSource
+            }
+
+        packageInfo =
+            { name =
+                dummyPackageName
+            , exposedModules =
+                Set.fromList
+                    [ dummyModuleName
+                    ]
+            }
+    in
+    mapSource (Options False) packageInfo defaultDependencies [ dummyModule ]
+        |> Result.mapError (\errorList -> errorList |> Debug.toString)
+        |> Result.andThen
+            (\packageDef ->
+                packageDef
+                    |> Package.mapDefinitionAttributes (always ()) (always ())
+                    |> .modules
+                    |> Dict.get dummyModuleName
+                    |> Maybe.andThen
+                        (\moduleDef ->
+                            moduleDef.value.values
+                                |> Dict.get dummyValueName
+                                |> Maybe.map (.value >> .body)
+                        )
+                    |> Result.fromMaybe "Cannot find parsed value"
+            )
 
 
 {-| -}
@@ -363,6 +424,12 @@ mapSource opts packageInfo dependencies sourceFiles =
                                         RecordPatternNotSupported sourceLocation ->
                                             mapSourceLocations
                                                 "Record pattern not supported"
+                                                sourceLocation
+                                                []
+
+                                        TypeInferenceError sourceLocation typeError ->
+                                            mapSourceLocations
+                                                ("Type inference error: " ++ Debug.toString typeError)
                                                 sourceLocation
                                                 []
                                 )
@@ -886,73 +953,87 @@ mapTypeAnnotation sourceFile (Node range typeAnnotation) =
 
 
 mapFunction : SourceFile -> Node Function -> Result Errors (Value.Definition SourceLocation SourceLocation)
-mapFunction sourceFile (Node range function) =
-    let
-        valueTypeResult : Result Errors (Type SourceLocation)
-        valueTypeResult =
-            case function.signature of
-                Just (Node _ signature) ->
-                    mapTypeAnnotation sourceFile signature.typeAnnotation
-
-                Nothing ->
-                    Err [ MissingTypeSignature (SourceLocation sourceFile range) ]
-    in
-    valueTypeResult
-        |> Result.andThen
-            (\valueType ->
-                function.declaration
-                    |> Node.value
-                    |> (\funImpl ->
-                            mapFunctionImplementation sourceFile valueType funImpl.arguments funImpl.expression
-                       )
-            )
-
-
-mapFunctionImplementation : SourceFile -> Type SourceLocation -> List (Node Pattern) -> Node Expression -> Result Errors (Value.Definition SourceLocation SourceLocation)
-mapFunctionImplementation sourceFile valueType argumentNodes expression =
+mapFunction sourceFile (Node functionRange function) =
     let
         sourceLocation : Range -> SourceLocation
         sourceLocation range =
             range |> SourceLocation sourceFile
 
-        extractNamedParams : List ( Name, SourceLocation, Type SourceLocation ) -> List (Node Pattern) -> Type SourceLocation -> ( List ( Name, SourceLocation, Type SourceLocation ), Type SourceLocation, List (Node Pattern) )
-        extractNamedParams namedParams patternParams restOfTypeSignature =
-            case ( patternParams, restOfTypeSignature ) of
-                ( [], _ ) ->
-                    ( namedParams, restOfTypeSignature, patternParams )
-
-                ( (Node range firstParam) :: restOfParams, Type.Function _ inType outType ) ->
-                    case firstParam of
-                        VarPattern paramName ->
-                            extractNamedParams (namedParams ++ [ ( Name.fromString paramName, range |> SourceLocation sourceFile, inType ) ]) restOfParams outType
-
-                        _ ->
-                            ( namedParams, restOfTypeSignature, patternParams )
-
-                _ ->
-                    ( namedParams, restOfTypeSignature, patternParams )
-
-        ( inputTypes, outputType, lambdaArgPatterns ) =
-            extractNamedParams [] argumentNodes valueType
-
-        bodyResult : Result Errors (Value.Value SourceLocation SourceLocation)
-        bodyResult =
-            let
-                lambdaWithParams : List (Node Pattern) -> Node Expression -> Result Errors (Value.Value SourceLocation SourceLocation)
-                lambdaWithParams params body =
-                    case params of
-                        [] ->
-                            mapExpression sourceFile body
-
-                        (Node range firstParam) :: restOfParams ->
-                            Result.map2 (\lambdaArg lambdaBody -> Value.Lambda (sourceLocation range) lambdaArg lambdaBody)
-                                (mapPattern sourceFile (Node range firstParam))
-                                (lambdaWithParams restOfParams body)
-            in
-            lambdaWithParams lambdaArgPatterns expression
+        expression : Node Expression
+        expression =
+            Node
+                functionRange
+                (Expression.LambdaExpression
+                    { args =
+                        function.declaration
+                            |> Node.value
+                            |> .arguments
+                    , expression =
+                        function.declaration
+                            |> Node.value
+                            |> .expression
+                    }
+                )
     in
-    bodyResult
-        |> Result.map (Value.Definition inputTypes outputType)
+    case function.signature of
+        Just (Node _ signature) ->
+            mapTypeAnnotation sourceFile signature.typeAnnotation
+                |> Result.andThen
+                    (\declaredType ->
+                        mapExpression sourceFile expression
+                            |> Result.map (Value.Definition [] declaredType)
+                    )
+                |> Result.map liftLambdaArguments
+
+        Nothing ->
+            let
+                exp =
+                    mapExpression sourceFile expression
+            in
+            exp
+                |> Result.andThen
+                    (\body ->
+                        Infer.inferValue IR.empty (body |> Value.mapValueAttributes (always ()) identity)
+                            |> Result.mapError (\err -> [ TypeInferenceError (sourceLocation functionRange) err ])
+                            |> Result.map (Value.valueAttribute >> Tuple.second >> Type.mapTypeAttributes (always (sourceLocation functionRange)))
+                    )
+                |> Result.andThen
+                    (\inferredType ->
+                        exp
+                            |> Result.map (Value.Definition [] inferredType)
+                    )
+                |> Result.map liftLambdaArguments
+
+
+{-| Moves lambda arguments into function arguments as much as possible. For example given this function definition:
+
+    foo : Int -> Bool -> ( Int, Int ) -> String
+    foo =
+        \a ->
+            \b ->
+                ( c, d ) ->
+                    doSomething a b c d
+
+It turns it into the following:
+
+    foo : Int -> Bool -> ( Int, Int ) -> String
+    foo a b =
+        ( c, d ) ->
+            doSomething a b c d
+
+-}
+liftLambdaArguments : Value.Definition ta va -> Value.Definition ta va
+liftLambdaArguments valueDef =
+    case ( valueDef.body, valueDef.outputType ) of
+        ( Value.Lambda va (Value.AsPattern _ (Value.WildcardPattern _) argName) lambdaBody, Type.Function _ argType returnType ) ->
+            liftLambdaArguments
+                { inputTypes = valueDef.inputTypes ++ [ ( argName, va, argType ) ]
+                , outputType = returnType
+                , body = lambdaBody
+                }
+
+        _ ->
+            valueDef
 
 
 mapExpression : SourceFile -> Node Expression -> Result Errors (Value.Value SourceLocation SourceLocation)

--- a/src/Morphir/Elm/Frontend/Codec.elm
+++ b/src/Morphir/Elm/Frontend/Codec.elm
@@ -60,6 +60,7 @@ import Morphir.Elm.Frontend.Resolve as Resolve
 import Morphir.IR.Name.Codec exposing (encodeName)
 import Morphir.IR.Path as Path
 import Morphir.JsonExtra as JsonExtra
+import Morphir.Type.Infer.Codec as InferCodec
 import Parser exposing (DeadEnd)
 import Set
 
@@ -160,6 +161,12 @@ encodeError error =
         RecordPatternNotSupported sourceLocation ->
             JsonExtra.encodeConstructor "RecordPatternNotSupported"
                 [ encodeSourceLocation sourceLocation
+                ]
+
+        TypeInferenceError sourceLocation typeError ->
+            JsonExtra.encodeConstructor "RecordPatternNotSupported"
+                [ encodeSourceLocation sourceLocation
+                , InferCodec.encodeTypeError typeError
                 ]
 
 

--- a/src/Morphir/Type/Infer/Codec.elm
+++ b/src/Morphir/Type/Infer/Codec.elm
@@ -5,7 +5,7 @@ import Json.Encode as Encode
 import Morphir.IR.FQName.Codec exposing (encodeFQName)
 import Morphir.IR.Name.Codec exposing (decodeName, encodeName)
 import Morphir.Type.Class.Codec exposing (encodeClass)
-import Morphir.Type.Infer exposing (TypeError(..), UnificationError(..), ValueTypeError(..))
+import Morphir.Type.Infer exposing (TypeError(..), ValueTypeError(..))
 import Morphir.Type.MetaType.Codec exposing (encodeMetaType)
 import Morphir.Type.MetaTypeMapping exposing (LookupError(..))
 
@@ -55,13 +55,11 @@ encodeTypeError typeError =
                 , Encode.string message
                 ]
 
-        CouldNotUnify unificationError metaType1 metaType2 ->
-            Encode.list identity
-                [ Encode.string "could_not_unify"
-                , encodeUnificationError unificationError
-                , encodeMetaType metaType1
-                , encodeMetaType metaType2
-                ]
+        RecursiveConstraint metaType metaType2 ->
+            Debug.todo "implement"
+
+        UnifyError unificationError ->
+            Debug.todo "implement"
 
 
 encodeLookupError : LookupError -> Encode.Value
@@ -89,28 +87,4 @@ encodeLookupError lookupError =
             Encode.list identity
                 [ Encode.string "expected_alias"
                 , encodeFQName fQName
-                ]
-
-
-encodeUnificationError : UnificationError -> Encode.Value
-encodeUnificationError unificationError =
-    case unificationError of
-        NoUnificationRule ->
-            Encode.list identity
-                [ Encode.string "no_unification_rule"
-                ]
-
-        TuplesOfDifferentSize ->
-            Encode.list identity
-                [ Encode.string "tuples_of_different_size"
-                ]
-
-        RefMismatch ->
-            Encode.list identity
-                [ Encode.string "ref_mismatch"
-                ]
-
-        FieldMismatch ->
-            Encode.list identity
-                [ Encode.string "field_mismatch"
                 ]

--- a/src/Morphir/Type/MetaType/Codec.elm
+++ b/src/Morphir/Type/MetaType/Codec.elm
@@ -16,19 +16,19 @@ encodeMetaType metaType =
                 , encodeVariable variable
                 ]
 
-        MetaRef fQName ->
+        MetaRef _ fQName _ _ ->
             Encode.list identity
                 [ Encode.string "meta_ref"
                 , encodeFQName fQName
                 ]
 
-        MetaTuple metaTypes ->
+        MetaTuple _ metaTypes ->
             Encode.list identity
                 [ Encode.string "meta_tuple"
                 , Encode.list encodeMetaType metaTypes
                 ]
 
-        MetaRecord maybeVar dict ->
+        MetaRecord _ maybeVar dict ->
             Encode.list identity
                 [ Encode.string "meta_record"
                 , case maybeVar of
@@ -48,14 +48,7 @@ encodeMetaType metaType =
                         )
                 ]
 
-        MetaApply metaType1 metaType2 ->
-            Encode.list identity
-                [ Encode.string "meta_apply"
-                , encodeMetaType metaType1
-                , encodeMetaType metaType2
-                ]
-
-        MetaFun metaType1 metaType2 ->
+        MetaFun _ metaType1 metaType2 ->
             Encode.list identity
                 [ Encode.string "meta_fun"
                 , encodeMetaType metaType1
@@ -67,14 +60,7 @@ encodeMetaType metaType =
                 [ Encode.string "meta_unit"
                 ]
 
-        MetaAlias fQName subject ->
-            Encode.list identity
-                [ Encode.string "meta_alias"
-                , encodeFQName fQName
-                , encodeMetaType subject
-                ]
-
 
 encodeVariable : Variable -> Encode.Value
-encodeVariable ( i, s ) =
-    Encode.list Encode.int [ i, s ]
+encodeVariable ( n, i, s ) =
+    Encode.list identity [ encodeName n, Encode.int i, Encode.int s ]


### PR DESCRIPTION
Added a new function to the Elm frontend that allows parsing a single expression. This also required eliminating the limitation on having to specify type signatures. #564




# Terms

> THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE TERMS OF THE CCLA DATED 2017-11-07 WITH FINOS/LINUX FOUNDATION (FORMERLY THE SYMPHONY SOFTWARE FOUNDATION CCLA).
>
> THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
