### PR TITLE
Order modules by dependency before inserting them into the Repo

### DIFF
--- a/src/Morphir/IR/Package.elm
+++ b/src/Morphir/IR/Package.elm
@@ -20,7 +20,7 @@ module Morphir.IR.Package exposing
     , Definition, emptyDefinition
     , lookupModuleSpecification, lookupModuleDefinition, lookupTypeSpecification, lookupValueSpecification, lookupValueDefinition
     , PackageName, definitionToSpecification, definitionToSpecificationWithPrivate, eraseDefinitionAttributes, eraseSpecificationAttributes
-    , mapDefinitionAttributes, mapSpecificationAttributes, selectModules
+    , mapDefinitionAttributes, mapSpecificationAttributes, selectModules, modulesOrderedByDependency
     )
 
 {-| A package is collection of types and values that are versioned together. If this sounds abstract just think of any
@@ -47,16 +47,17 @@ including implementation and private types and values.
 # Other utilities
 
 @docs PackageName, definitionToSpecification, definitionToSpecificationWithPrivate, eraseDefinitionAttributes, eraseSpecificationAttributes
-@docs mapDefinitionAttributes, mapSpecificationAttributes, selectModules
+@docs mapDefinitionAttributes, mapSpecificationAttributes, selectModules, modulesOrderedByDependency
 
 -}
 
 import Dict exposing (Dict)
+import Morphir.Dependency.DAG as DAG exposing (DAG)
 import Morphir.IR.AccessControlled exposing (AccessControlled, withPrivateAccess, withPublicAccess)
 import Morphir.IR.Module as Module exposing (ModuleName)
 import Morphir.IR.Name exposing (Name)
 import Morphir.IR.Path exposing (Path)
-import Morphir.IR.Type as Type
+import Morphir.IR.Type as Type exposing (Type)
 import Morphir.IR.Value as Value
 import Set exposing (Set)
 
@@ -281,3 +282,48 @@ selectModules modulesToInclude packageName packageDef =
 
     else
         selectModules expandedModulesToInclude packageName packageDef
+
+
+{-| Get the list of modules within this package ordered by dependency. If module B depends on A than module B is
+guaranteed to be after A in the list.
+-}
+modulesOrderedByDependency : PackageName -> Definition () (Type ()) -> List ( ModuleName, AccessControlled (Module.Definition () (Type ())) )
+modulesOrderedByDependency packageName packageDef =
+    let
+        -- Build a dependency graph of modules
+        moduleDependencies : DAG ModuleName
+        moduleDependencies =
+            packageDef.modules
+                |> Dict.toList
+                |> List.foldl
+                    (\( moduleName, accessControlledModuleDef ) dagSoFar ->
+                        let
+                            dependsOnModules : Set ModuleName
+                            dependsOnModules =
+                                accessControlledModuleDef.value
+                                    |> Module.dependsOnModules
+                                    -- Keep only dependencies within the package
+                                    |> Set.filter (\( dependsOnPackage, _ ) -> dependsOnPackage == packageName)
+                                    -- Remove the package name
+                                    |> Set.map Tuple.second
+                        in
+                        dagSoFar
+                            |> DAG.insertNode moduleName dependsOnModules
+                            -- We assume that there are no cycles in an existing distribution
+                            -- If there are cycles (which should never happen) we skip the node causing the cycle
+                            |> Result.withDefault dagSoFar
+                    )
+                    DAG.empty
+    in
+    moduleDependencies
+        -- Use the dependency graph to order the modules topologically
+        |> DAG.backwardTopologicalOrdering
+        -- Turn the partial ordering represented as a list of lists into a simple list
+        |> List.concat
+        -- Look up the module definition for each module name
+        |> List.filterMap
+            (\moduleName ->
+                packageDef.modules
+                    |> Dict.get moduleName
+                    |> Maybe.map (Tuple.pair moduleName)
+            )

--- a/src/Morphir/IR/Repo.elm
+++ b/src/Morphir/IR/Repo.elm
@@ -65,8 +65,7 @@ fromDistribution : Distribution -> Result Errors Repo
 fromDistribution distro =
     case distro of
         Library packageName _ packageDef ->
-            packageDef.modules
-                |> Dict.toList
+            Package.modulesOrderedByDependency packageName packageDef
                 |> List.foldl
                     (\( moduleName, accessControlledModuleDef ) repoResultSoFar ->
                         repoResultSoFar


### PR DESCRIPTION
Order modules by dependency before inserting them into the Repo while building from a Distribution.




# Terms

> THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE TERMS OF THE CCLA DATED 2017-11-07 WITH FINOS/LINUX FOUNDATION (FORMERLY THE SYMPHONY SOFTWARE FOUNDATION CCLA).
>
> THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
