### PR TITLE
Translate Maybes in Spark

### DIFF
--- a/docs/developers-guide/files/spark-backend.md
+++ b/docs/developers-guide/files/spark-backend.md
@@ -201,6 +201,28 @@ Maybes are how Elm makes it possible to return a value or Nothing, equivalent to
 In Spark, all pure Spark functions and operators handle null gracefully
 (usually returning null itself if any operand is null).
 
+**Just** <br>
+In Elm, comparison against Maybes must be explicitly against `Just <Value>`.
+In Spark, no special treatment is needed to compare against a value that may be null.
+Therefore, elm code that looks like:
+```
+testMaybeBoolConditional : List { foo: Maybe Bool } -> List { foo : Maybe Bool }
+testMaybeBoolConditional source =
+    source
+        |> List.filter
+            (\a ->
+                a.foo == Just True
+            )
+```
+gets translated in Spark to
+```
+  def testMaybeBoolConditional(
+    source: org.apache.spark.sql.DataFrame
+  ): org.apache.spark.sql.DataFrame =
+    source.filter((org.apache.spark.sql.functions.col("foo")) === (true))
+```
+
+**Nothing** <br>
 Where Elm code compares against Nothing, Morphir will translate this into a comparison to null in Spark.
 
 For example, to take a list of records and filter out null records in Elm, we would do:

--- a/docs/developers-guide/files/spark-backend.md
+++ b/docs/developers-guide/files/spark-backend.md
@@ -196,6 +196,32 @@ gets translated into
     source.filter((org.apache.spark.sql.functions.col("foo")) === ("bar"))
 ```
 
+_**Maybe**_ <br>
+Maybes are how Elm makes it possible to return a value or Nothing, equivalent to null in other languages.
+In Spark, all pure Spark functions and operators handle null gracefully
+(usually returning null itself if any operand is null).
+
+Where Elm code compares against Nothing, Morphir will translate this into a comparison to null in Spark.
+
+For example, to take a list of records and filter out null records in Elm, we would do:
+```
+testMaybeBoolConditionalNull : List { foo : Maybe Bool } -> List { foo : Maybe Bool }
+testMaybeBoolConditionalNull source =
+    source
+        |> List.filter
+            (\a ->
+                a.foo == Nothing
+            )
+```
+
+In Spark, this would be:
+```
+def testMaybeBoolConditional(
+  source: org.apache.spark.sql.DataFrame
+): org.apache.spark.sql.DataFrame =
+  source.filter(org.apache.spark.sql.functions.isnull(org.apache.spark.sql.functions.col("foo")))
+```
+
 # Spark Backend
 
 **mapDistribution**

--- a/docs/developers-guide/files/spark-backend.md
+++ b/docs/developers-guide/files/spark-backend.md
@@ -244,6 +244,46 @@ def testMaybeBoolConditional(
   source.filter(org.apache.spark.sql.functions.isnull(org.apache.spark.sql.functions.col("foo")))
 ```
 
+**Maybe.map** <br>
+
+Elm has `Maybe.map` and `Maybe.defaultValue` to take a Maybe and execute one branch of code if the Maybe isn't Nothing,
+and another branch if it is.
+
+The equivalent in Spark is to use `where` to execute one branch of code if the value isn't null, and `otherwise` for
+the default case.
+For example:
+```
+testMaybeMapDefault : List { foo : Maybe Bool } -> List { foo : Maybe Bool }
+testMaybeMapDefault source =
+    source
+        |> List.filter
+            (\item ->
+                item.foo
+                    |> Maybe.map
+                        (\a ->
+                            if a == False then
+                                True
+                            else
+                                False
+                        )
+                    |> Maybe.withDefault False
+            )
+```
+
+In Spark, this would be:
+```
+def testMaybeMapDefault(
+  source: org.apache.spark.sql.DataFrame
+): org.apache.spark.sql.DataFrame =
+  source.filter(org.apache.spark.sql.functions.when(
+    org.apache.spark.sql.functions.not(org.apache.spark.sql.functions.isnull(org.apache.spark.sql.functions.col("foo"))),
+    org.apache.spark.sql.functions.when(
+      (org.apache.spark.sql.functions.col("foo")) === (false),
+      true
+    ).otherwise(false)
+  ).otherwise(false))
+```
+
 # Spark Backend
 
 **mapDistribution**

--- a/src/Morphir/Spark/AST.elm
+++ b/src/Morphir/Spark/AST.elm
@@ -226,6 +226,14 @@ expressionFromValue ir morphirValue =
 
         Value.Apply _ _ _ ->
             case morphirValue of
+                Value.Apply _ (Value.Apply _ (Value.Reference _ ( [ [ "morphir" ], [ "s", "d", "k" ] ], [ [ "basics" ] ], [ "not", "equal" ] )) arg) (Value.Constructor _ ( [ [ "morphir" ], [ "s", "d", "k" ] ], [ [ "maybe" ] ], [ "nothing" ] )) ->
+                    -- `arg /= Nothing` becomes `not(isnull(arg))`
+                    expressionFromValue ir arg
+                        |> Result.map (\expr -> Function "not" [Function "isnull" [expr]])
+                Value.Apply _ (Value.Apply _ (Value.Reference _ ( [ [ "morphir" ], [ "s", "d", "k" ] ], [ [ "basics" ] ], [ "equal" ] )) arg) (Value.Constructor _ ( [ [ "morphir" ], [ "s", "d", "k" ] ], [ [ "maybe" ] ], [ "nothing" ] )) ->
+                    -- `arg == Nothing` becomes `isnull(arg)`
+                    expressionFromValue ir arg
+                        |> Result.map (\expr -> Function "isnull" [expr])
                 Value.Apply _ (Value.Apply _ (Value.Reference _ (( package, modName, _ ) as ref)) arg) argValue ->
                     case ( package, modName ) of
                         ( [ [ "morphir" ], [ "s", "d", "k" ] ], [ [ "basics" ] ] ) ->

--- a/src/Morphir/Spark/AST.elm
+++ b/src/Morphir/Spark/AST.elm
@@ -39,7 +39,7 @@ generator uses.
 import Array exposing (Array)
 import Morphir.IR as IR exposing (..)
 import Morphir.IR.FQName as FQName exposing (FQName)
-import Morphir.IR.Literal exposing (Literal)
+import Morphir.IR.Literal exposing (Literal(..))
 import Morphir.IR.Name as Name exposing (Name)
 import Morphir.IR.Type as Type
 import Morphir.IR.Value as Value exposing (TypedValue)
@@ -261,15 +261,15 @@ expressionFromValue ir morphirValue =
                             |> replaceLambdaArg sourceValue
                             |> Result.andThen (expressionFromValue ir))
                         (expressionFromValue ir elseValue)
-                Value.Apply _ (Value.Constructor _ ( [ [ "morphir" ], [ "s","d" ,"k" ] ], [ [ "maybe" ] ], [ "just" ] ) ) arg ->
-                    -- `Just arg` becomes `arg`
+                Value.Apply _ (Value.Literal (Type.Function _ _ (Type.Reference _ ( [ [ "morphir" ], [ "s","d" ,"k" ] ], [ [ "maybe" ] ], [ "maybe" ] ) _ ) ) (StringLiteral "Just") ) arg ->
+                    -- `Just arg` becomes `arg` if `Just` was a Maybe.
                     expressionFromValue ir arg
-                Value.Apply _ (Value.Apply _ (Value.Reference _ ( [ [ "morphir" ], [ "s", "d", "k" ] ], [ [ "basics" ] ], [ "not", "equal" ] )) arg) (Value.Constructor _ ( [ [ "morphir" ], [ "s", "d", "k" ] ], [ [ "maybe" ] ], [ "nothing" ] )) ->
-                    -- `arg /= Nothing` becomes `not(isnull(arg))`
+                Value.Apply _ (Value.Apply _ (Value.Reference _ ( [ [ "morphir" ], [ "s", "d", "k" ] ], [ [ "basics" ] ], [ "not", "equal" ] )) arg) (Value.Literal (Type.Reference _ ( [ [ "morphir" ], [ "s","d" ,"k" ] ], [ [ "maybe" ] ], [ "maybe" ] ) _ ) (StringLiteral "Nothing") ) ->
+                    -- `arg /= Nothing` becomes `not(isnull(arg))` if `Nothing` was a Maybe.
                     expressionFromValue ir arg
                         |> Result.map (\expr -> Function "not" [Function "isnull" [expr]])
-                Value.Apply _ (Value.Apply _ (Value.Reference _ ( [ [ "morphir" ], [ "s", "d", "k" ] ], [ [ "basics" ] ], [ "equal" ] )) arg) (Value.Constructor _ ( [ [ "morphir" ], [ "s", "d", "k" ] ], [ [ "maybe" ] ], [ "nothing" ] )) ->
-                    -- `arg == Nothing` becomes `isnull(arg)`
+                Value.Apply _ (Value.Apply _ (Value.Reference _ ( [ [ "morphir" ], [ "s", "d", "k" ] ], [ [ "basics" ] ], [ "equal" ] )) arg) (Value.Literal (Type.Reference _ ( [ [ "morphir" ], [ "s","d" ,"k" ] ], [ [ "maybe" ] ], [ "maybe" ] ) _ ) (StringLiteral "Nothing") ) ->
+                    -- `arg == Nothing` becomes `isnull(arg)` if `Nothing` was a Maybe.
                     expressionFromValue ir arg
                         |> Result.map (\expr -> Function "isnull" [expr])
                 Value.Apply _ (Value.Apply _ (Value.Reference _ (( package, modName, _ ) as ref)) arg) argValue ->

--- a/src/Morphir/Spark/AST.elm
+++ b/src/Morphir/Spark/AST.elm
@@ -226,6 +226,9 @@ expressionFromValue ir morphirValue =
 
         Value.Apply _ _ _ ->
             case morphirValue of
+                Value.Apply _ (Value.Constructor _ ( [ [ "morphir" ], [ "s" ,"d" ,"k" ] ], [ [ "maybe" ] ], [ "just" ] ) ) arg ->
+                    -- `Just arg` becomes `arg`
+                    expressionFromValue ir arg
                 Value.Apply _ (Value.Apply _ (Value.Reference _ ( [ [ "morphir" ], [ "s", "d", "k" ] ], [ [ "basics" ] ], [ "not", "equal" ] )) arg) (Value.Constructor _ ( [ [ "morphir" ], [ "s", "d", "k" ] ], [ [ "maybe" ] ], [ "nothing" ] )) ->
                     -- `arg /= Nothing` becomes `not(isnull(arg))`
                     expressionFromValue ir arg

--- a/tests-integration/spark/model/src/SparkTests/TypeTests.elm
+++ b/tests-integration/spark/model/src/SparkTests/TypeTests.elm
@@ -51,6 +51,34 @@ testMaybeBoolConditionalNotNull source =
             )
 
 
+testMaybeFloat : List { foo : Maybe Float } -> List { foo : Maybe Float }
+testMaybeFloat source =
+    source
+        |> List.filter
+            (\a ->
+                if a.foo == Just 9.99 then
+                    True
+                else if a.foo /= Nothing then
+                    True
+                else
+                    False
+            )
+
+
+testMaybeInt : List { foo : Maybe Int } -> List { foo : Maybe Int }
+testMaybeInt source =
+    source
+        |> List.filter
+            (\a ->
+                if a.foo == Just 13 then
+                    True
+                else if a.foo /= Nothing then
+                    True
+                else
+                    False
+            )
+
+
 testMaybeMapDefault : List { foo : Maybe Bool } -> List { foo : Maybe Bool }
 testMaybeMapDefault source =
     source
@@ -65,6 +93,20 @@ testMaybeMapDefault source =
                                 False
                         )
                     |> Maybe.withDefault False
+            )
+
+
+testMaybeString : List { foo : Maybe String } -> List { foo : Maybe String }
+testMaybeString source =
+    source
+        |> List.filter
+            (\a ->
+                if a.foo == Just "bar" then
+                    True
+                else if a.foo /= Nothing then
+                    True
+                else
+                    False
             )
 
 

--- a/tests-integration/spark/model/src/SparkTests/TypeTests.elm
+++ b/tests-integration/spark/model/src/SparkTests/TypeTests.elm
@@ -26,6 +26,14 @@ testInt source =
                 a.foo == 13
             )
 
+testMaybeBoolConditional : List { foo: Maybe Bool } -> List { foo : Maybe Bool }
+testMaybeBoolConditional source =
+    source
+        |> List.filter
+            (\a ->
+                a.foo == Just True
+            )
+
 testMaybeBoolConditionalNull : List { foo : Maybe Bool } -> List { foo : Maybe Bool }
 testMaybeBoolConditionalNull source =
     source

--- a/tests-integration/spark/model/src/SparkTests/TypeTests.elm
+++ b/tests-integration/spark/model/src/SparkTests/TypeTests.elm
@@ -26,6 +26,22 @@ testInt source =
                 a.foo == 13
             )
 
+testMaybeBoolConditionalNull : List { foo : Maybe Bool } -> List { foo : Maybe Bool }
+testMaybeBoolConditionalNull source =
+    source
+        |> List.filter
+            (\a ->
+                a.foo == Nothing
+            )
+
+testMaybeBoolConditionalNotNull : List { foo : Maybe Bool } -> List { foo : Maybe Bool }
+testMaybeBoolConditionalNotNull source =
+    source
+        |> List.filter
+            (\a ->
+                a.foo /= Nothing
+            )
+
 testString : List { foo : String } -> List { foo : String }
 testString source =
     source

--- a/tests-integration/spark/model/src/SparkTests/TypeTests.elm
+++ b/tests-integration/spark/model/src/SparkTests/TypeTests.elm
@@ -50,6 +50,24 @@ testMaybeBoolConditionalNotNull source =
                 a.foo /= Nothing
             )
 
+
+testMaybeMapDefault : List { foo : Maybe Bool } -> List { foo : Maybe Bool }
+testMaybeMapDefault source =
+    source
+        |> List.filter
+            (\item ->
+                item.foo
+                    |> Maybe.map
+                        (\a ->
+                            if a == False then
+                                True
+                            else
+                                False
+                        )
+                    |> Maybe.withDefault False
+            )
+
+
 testString : List { foo : String } -> List { foo : String }
 testString source =
     source

--- a/tests-integration/spark/test/src/SparkTypeTest.scala
+++ b/tests-integration/spark/test/src/SparkTypeTest.scala
@@ -43,6 +43,20 @@ class SparkTypeTest extends FunSuite {
     assert(result.collect()(0)(0) == good_value)
   }
 
+  test("testMaybeMapDefault") {
+    val data = Seq(Row(null, "bax"), Row(true, "bay"), Row(false, "baz"))
+    val schema = StructType(List(
+      StructField("foo", BooleanType, true),
+      StructField("bar", StringType, false),
+    ))
+    val rdd = localTestSession.sparkContext.parallelize(data)
+    val df = localTestSession.createDataFrame(rdd, schema)
+    val result = SparkJobs.testMaybeMapDefault(df)
+    assert(result.count() == 1)
+    assert(result.collect()(0)(0) == false)
+    assert(result.collect()(0)(1) == "baz")
+  }
+
   test("testMaybeBoolConditional") {
     val data = Seq(Row(null, "baz"), Row(true, "baz"))
     val schema = StructType(List(

--- a/tests-integration/spark/test/src/SparkTypeTest.scala
+++ b/tests-integration/spark/test/src/SparkTypeTest.scala
@@ -43,6 +43,19 @@ class SparkTypeTest extends FunSuite {
     assert(result.collect()(0)(0) == good_value)
   }
 
+  test("testMaybeBoolConditional") {
+    val data = Seq(Row(null, "baz"), Row(true, "baz"))
+    val schema = StructType(List(
+      StructField("foo", BooleanType, true),
+      StructField("bar", StringType, false),
+    ))
+    val rdd = localTestSession.sparkContext.parallelize(data)
+    val df = localTestSession.createDataFrame(rdd, schema)
+    val result = SparkJobs.testMaybeBoolConditional(df)
+    assert(result.count() == 1)
+    assert(result.collect()(0)(0) == true)
+  }
+
   test("testMaybeBoolConditonalNull") {
     val data = Seq(Row(null, "baz"), Row(true, "baz"))
     val schema = StructType(List(

--- a/tests-integration/spark/test/src/SparkTypeTest.scala
+++ b/tests-integration/spark/test/src/SparkTypeTest.scala
@@ -2,6 +2,8 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.functions.explode
 import org.scalatest.FunSuite
 import sparktests.typetests.SparkJobs
+import org.apache.spark.sql.types.{BooleanType, StringType, StructField, StructType}
+import org.apache.spark.sql.Row
 
 class SparkTypeTest extends FunSuite {
   val localTestSession =
@@ -39,6 +41,32 @@ class SparkTypeTest extends FunSuite {
     val result = SparkJobs.testInt(df)
     assert(result.count() == 1)
     assert(result.collect()(0)(0) == good_value)
+  }
+
+  test("testMaybeBoolConditonalNull") {
+    val data = Seq(Row(null, "baz"), Row(true, "baz"))
+    val schema = StructType(List(
+      StructField("foo", BooleanType, true),
+      StructField("bar", StringType, false),
+    ))
+    val rdd = localTestSession.sparkContext.parallelize(data)
+    val df = localTestSession.createDataFrame(rdd, schema)
+    val result = SparkJobs.testMaybeBoolConditionalNull(df)
+    assert(result.count() == 1)
+    assert(result.collect()(0)(0) == null)
+  }
+
+  test("testMaybeBoolConditonalNotNull") {
+    val data = Seq(Row(null, "baz"), Row(true, "baz"))
+    val schema = StructType(List(
+      StructField("foo", BooleanType, true),
+      StructField("bar", StringType, false),
+    ))
+    val rdd = localTestSession.sparkContext.parallelize(data)
+    val df = localTestSession.createDataFrame(rdd, schema)
+    val result = SparkJobs.testMaybeBoolConditionalNotNull(df)
+    assert(result.count() == 1)
+    assert(result.collect()(0)(0) == true)
   }
 
   test("testString") {

--- a/tests-integration/spark/test/src/SparkTypeTest.scala
+++ b/tests-integration/spark/test/src/SparkTypeTest.scala
@@ -2,7 +2,7 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.functions.explode
 import org.scalatest.FunSuite
 import sparktests.typetests.SparkJobs
-import org.apache.spark.sql.types.{BooleanType, StringType, StructField, StructType}
+import org.apache.spark.sql.types.{BooleanType, FloatType, IntegerType, StringType, StructField, StructType}
 import org.apache.spark.sql.Row
 
 class SparkTypeTest extends FunSuite {
@@ -41,6 +41,34 @@ class SparkTypeTest extends FunSuite {
     val result = SparkJobs.testInt(df)
     assert(result.count() == 1)
     assert(result.collect()(0)(0) == good_value)
+  }
+
+  test("testMaybeFloat") {
+    val data = Seq(Row(9.99f, "bax"), Row(5.55f, "bar"), Row(null, "baz"))
+    val schema = StructType(List(
+      StructField("foo", FloatType, true),
+      StructField("bar", StringType, false),
+    ))
+    val rdd = localTestSession.sparkContext.parallelize(data)
+    val df = localTestSession.createDataFrame(rdd, schema)
+    val result = SparkJobs.testMaybeFloat(df)
+    assert(result.count() == 2)
+    assert(result.collect()(0)(0) == 9.99f)
+    assert(result.collect()(1)(0) == 5.55f)
+  }
+
+  test("testMaybeInt") {
+    val data = Seq(Row(13, "bax"), Row(8, "bar"), Row(null, "baz"))
+    val schema = StructType(List(
+      StructField("foo", IntegerType, true),
+      StructField("bar", StringType, false),
+    ))
+    val rdd = localTestSession.sparkContext.parallelize(data)
+    val df = localTestSession.createDataFrame(rdd, schema)
+    val result = SparkJobs.testMaybeInt(df)
+    assert(result.count() == 2)
+    assert(result.collect()(0)(0) == 13)
+    assert(result.collect()(1)(0) == 8)
   }
 
   test("testMaybeMapDefault") {
@@ -94,6 +122,19 @@ class SparkTypeTest extends FunSuite {
     val result = SparkJobs.testMaybeBoolConditionalNotNull(df)
     assert(result.count() == 1)
     assert(result.collect()(0)(0) == true)
+  }
+
+  test("testMaybeString") {
+    val data = Seq(Row("foo"), Row("bar"), Row(null))
+    val schema = StructType(List(
+      StructField("foo", StringType, true),
+    ))
+    val rdd = localTestSession.sparkContext.parallelize(data)
+    val df = localTestSession.createDataFrame(rdd, schema)
+    val result = SparkJobs.testMaybeString(df)
+    assert(result.count() == 2)
+    assert(result.collect()(0)(0) == "foo")
+    assert(result.collect()(1)(0) == "bar")
   }
 
   test("testString") {


### PR DESCRIPTION
I have some (untested) translation of comparisons against Nothing into checking whether a column is null.
My pattern match in Spark/AST.elm looks extremely clumsy so I'd appreciate some advice on how to make it more readable.

There are tests, but they currently don't work because I'm having trouble generating a valid dataframe that has a column that may be a boolean or null.

# Terms

> THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE TERMS OF THE CCLA DATED 2017-11-07 WITH FINOS/LINUX FOUNDATION (FORMERLY THE SYMPHONY SOFTWARE FOUNDATION CCLA).
>
> THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
