### PR TITLE
Rdale/spark backend enums as strings

### DIFF
--- a/src/Morphir/Spark/Backend.elm
+++ b/src/Morphir/Spark/Backend.elm
@@ -34,8 +34,10 @@ import Dict exposing (Dict)
 import Morphir.File.FileMap exposing (FileMap)
 import Morphir.IR as IR exposing (IR)
 import Morphir.IR.Distribution as Distribution exposing (Distribution)
+import Morphir.IR.Documented as Documented exposing (Documented)
 import Morphir.IR.FQName exposing (FQName)
 import Morphir.IR.Literal exposing (Literal(..))
+import Morphir.IR.Module as Module exposing (ModuleName)
 import Morphir.IR.Name as Name exposing (Name)
 import Morphir.IR.Type as Type exposing (Type)
 import Morphir.IR.Value exposing (TypedValue, Value)
@@ -45,7 +47,10 @@ import Morphir.Scala.Backend as ScalaBackend
 import Morphir.Scala.PrettyPrinter as PrettyPrinter
 import Morphir.Spark.API as Spark
 import Morphir.Spark.AST as SparkAST exposing (..)
-
+import Morphir.IR.FQName as FQName exposing (FQName)
+import Morphir.IR.Value as Value exposing (TypedValue)
+import Morphir.IR.AccessControlled as AccessControlled exposing (Access(..), AccessControlled)
+import Morphir.IR.Value as Value exposing (Value)
 
 type alias Options =
     {}
@@ -62,12 +67,15 @@ representation of files generated.
 -}
 mapDistribution : Options -> Distribution -> FileMap
 mapDistribution _ distro =
-    case distro of
+    let
+        fixedDistro = fixDistribution distro
+    in
+    case fixedDistro of
         Distribution.Library packageName _ packageDef ->
             let
                 ir : IR
                 ir =
-                    IR.fromDistribution distro
+                    IR.fromDistribution fixedDistro
             in
             packageDef.modules
                 |> Dict.toList
@@ -119,6 +127,83 @@ mapDistribution _ distro =
                         )
                     )
                 |> Dict.fromList
+
+
+{-| Fix up the modules in the Distribution prior to generating Spark code
+-}
+fixDistribution : Distribution ->  Distribution
+fixDistribution distribution =
+    case distribution of
+        Distribution.Library libraryPackageName dependencies packageDef ->
+            let
+                updatedModules =
+                    packageDef.modules
+                        |> Dict.toList
+                        |> List.map
+                            (\( moduleName, accessControlledModuleDef ) ->
+                                let
+                                    updatedAccessControlledModuleDef =
+                                        accessControlledModuleDef
+                                            |> AccessControlled.map fixModuleDef
+                                in
+                                (moduleName, updatedAccessControlledModuleDef)
+                            )
+                        |> Dict.fromList
+
+            in
+            Distribution.Library libraryPackageName dependencies { packageDef | modules = updatedModules }
+
+
+{-| Fix up the values in a Module Definition prior to generating Spark code
+-}
+fixModuleDef : Module.Definition ta va -> Module.Definition ta va
+fixModuleDef moduleDef =
+    let
+        updatedValues =
+            moduleDef.values
+                |> Dict.toList
+                |> List.map
+                    (\( valueName, accessControlledValueDef ) ->
+                        let
+                            updatedAccessControlledValueDef =
+                                accessControlledValueDef
+                                    |> AccessControlled.map
+                                        (\ documentedValueDef ->
+                                            documentedValueDef
+                                                |> Documented.map
+                                                    (\ valueDef ->
+                                                        { valueDef | body = mapEnumToLiteral valueDef.body }
+                                                    )
+                                        )
+                        in
+                        (valueName, updatedAccessControlledValueDef)
+                    )
+                |> Dict.fromList
+    in
+    { moduleDef | values = updatedValues }
+
+
+{-| Replace no argument union constructors which correspond to enums, with string literals.
+-}
+mapEnumToLiteral : Value ta va -> Value ta va
+mapEnumToLiteral value =
+    value
+        |> Value.rewriteValue
+            (\currentValue ->
+                case currentValue of
+                    Value.Constructor va fqn ->
+                        let
+                            literal = fqn
+                                |> FQName.getLocalName
+                                |> Name.toTitleCase
+                                |> StringLiteral
+                                |> Value.Literal va
+                        in
+                        Just literal
+
+                    _  ->
+                        Nothing
+            )
 
 
 {-| Maps function definitions defined within the current package to scala

--- a/tests-integration/spark/model/src/SparkTests/TypeTests.elm
+++ b/tests-integration/spark/model/src/SparkTests/TypeTests.elm
@@ -1,5 +1,7 @@
 module SparkTests.TypeTests exposing (..)
 
+import SparkTests.Types exposing (..)
+
 testBool : List { foo : Bool } -> List { foo : Bool }
 testBool source =
     source
@@ -30,5 +32,13 @@ testString source =
         |> List.filter
             (\a ->
                 a.foo == "bar"
+            )
+
+testEnum : List { title : Title } -> List { title : Title }
+testEnum source =
+    source
+        |> List.filter
+            (\a ->
+                a.title == ED
             )
 

--- a/tests-integration/spark/test/src/SparkTypeTest.scala
+++ b/tests-integration/spark/test/src/SparkTypeTest.scala
@@ -52,5 +52,15 @@ class SparkTypeTest extends FunSuite {
     assert(result.collect()(0)(0) == good_value)
   }
 
+  test("testEnum") {
+    val bad_value = "VP"
+    val good_value = "ED"
+    val data = Seq((bad_value), (good_value))
+    val rdd = localTestSession.sparkContext.parallelize(data)
+    val df = rdd.toDF("title")
+    val result = SparkJobs.testEnum(df)
+    assert(result.count() == 1)
+    assert(result.collect()(0)(0) == good_value)
+  }
 
 }


### PR DESCRIPTION


# Terms

> THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE TERMS OF THE CCLA DATED 2017-11-07 WITH FINOS/LINUX FOUNDATION (FORMERLY THE SYMPHONY SOFTWARE FOUNDATION CCLA).
>
> THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
