### PR TITLE
Add documentation for Spark Enum types

### DIFF
--- a/docs/developers-guide/files/spark-backend.md
+++ b/docs/developers-guide/files/spark-backend.md
@@ -223,6 +223,29 @@ gets translated into
     source.filter((org.apache.spark.sql.functions.col("foo")) === ("bar"))
 ```
 
+_**Enum**_ <br>
+Elm Union types with no arguments (or Constructors in Morphir IR), are translated into String Literals.
+For instance:
+```
+testEnum : List { product : Product } -> List { product : Product }
+testEnum source =
+    source
+        |> List.filter
+            (\a ->
+                a.product == Plates
+            )
+```
+gets translated into
+```
+  def testEnum(
+    source: org.apache.spark.sql.DataFrame
+  ): org.apache.spark.sql.DataFrame =
+    source.filter((org.apache.spark.sql.functions.col("product")) === ("Plates"))
+```
+
+Currently the implementation doesn't check that the Constructor has no arguments. 
+Nor does the current implementation check whether a Constructor has Public access, and only consider those to be Enums.
+
 _**Maybe**_ <br>
 Maybes are how Elm makes it possible to return a value or Nothing, equivalent to null in other languages.
 In Spark, all pure Spark functions and operators handle null gracefully


### PR DESCRIPTION


# Terms

> THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE TERMS OF THE CCLA DATED 2017-11-07 WITH FINOS/LINUX FOUNDATION (FORMERLY THE SYMPHONY SOFTWARE FOUNDATION CCLA).
>
> THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
