### PR TITLE
Revert "Trying to fix the npm deploy"

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -93,8 +93,6 @@ jobs:
           mkdir -p ~/artifact-download/morphir-elm-artifact
           tar -zxvf $(ls ~/artifact-download/*.tgz)  -C ~/artifact-download/morphir-elm-artifact
           ls -l ~/artifact-download/morphir-elm-artifact
-      - name: Install
-        run: npm install
 
       - name: Auto release
         if: "env.NPM_TOKEN != 0 && !contains(github.event.head_commit.message, 'ci skip') && !contains(github.event.head_commit.message, 'ci skip')"


### PR DESCRIPTION
Reverts finos/morphir-elm#822

It didn't work
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.65.5--canary.824.2735562135.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install morphir-elm@2.65.5--canary.824.2735562135.0
  # or 
  yarn add morphir-elm@2.65.5--canary.824.2735562135.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
