### PR TITLE
Automate execution for Spark CSV generators

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -277,10 +277,10 @@ function testIntegrationTestTypeScript(cb) {
 
 
 async function testCreateCSV(cb) {
-    if (!shell.which('sh')){
+    if (!shell.which('bash')){
         console.log("Automatically creating CSV files is not available on this platform");
     } else {
-        code_no = shell.exec('sh ./create_csv_files.sh', {cwd : './tests-integration/spark/elm-tests/tests'}).code
+        code_no = shell.exec('bash ./create_csv_files.sh', {cwd : './tests-integration/spark/elm-tests/tests'}).code
         if (code_no != 0){
             console.log('ERROR: CSV files cannot be created')
             return false;

--- a/tests-integration/spark/elm-tests/src/AntiqueAgeDataSource.elm
+++ b/tests-integration/spark/elm-tests/src/AntiqueAgeDataSource.elm
@@ -22,8 +22,8 @@ import CsvUtils exposing (..)
 import SparkTests.Types exposing (..)
 
 
-csvAgeData : String
-csvAgeData =
+csvData : String
+csvData =
     """ageOfItem
 -1.0
 0.0
@@ -38,4 +38,4 @@ csvAgeData =
 
 antiqueAgeDataSource : Result Error (List AgeRecord)
 antiqueAgeDataSource =
-    Decode.decodeCsv Decode.FieldNamesFromFirstRow antiqueAgeDecoder csvAgeData
+    Decode.decodeCsv Decode.FieldNamesFromFirstRow antiqueAgeDecoder csvData

--- a/tests-integration/spark/elm-tests/src/AntiqueNameDataSource.elm
+++ b/tests-integration/spark/elm-tests/src/AntiqueNameDataSource.elm
@@ -22,8 +22,8 @@ import CsvUtils exposing (..)
 import SparkTests.Types exposing (..)
 
 
-csvNameData : String
-csvNameData =
+csvData : String
+csvData =
     """name
 Upright Chair
 Small Table
@@ -42,4 +42,4 @@ Item7868
 
 antiqueNameDataSource : Result Error (List NameRecord)
 antiqueNameDataSource =
-    Decode.decodeCsv Decode.FieldNamesFromFirstRow antiqueNameDecoder csvNameData
+    Decode.decodeCsv Decode.FieldNamesFromFirstRow antiqueNameDecoder csvData

--- a/tests-integration/spark/elm-tests/src/AntiqueProductDataSource.elm
+++ b/tests-integration/spark/elm-tests/src/AntiqueProductDataSource.elm
@@ -22,8 +22,8 @@ import CsvUtils exposing (..)
 import SparkTests.Types exposing (..)
 
 
-csvProductData : String
-csvProductData =
+csvData : String
+csvData =
     """product
 Paintings
 Knife
@@ -35,4 +35,4 @@ HistoryWritings
 
 antiqueProductDataSource : Result Error (List ProductRecord)
 antiqueProductDataSource =
-    Decode.decodeCsv Decode.FieldNamesFromFirstRow antiqueProductDecoder csvProductData
+    Decode.decodeCsv Decode.FieldNamesFromFirstRow antiqueProductDecoder csvData

--- a/tests-integration/spark/elm-tests/src/AntiqueSSDataSource.elm
+++ b/tests-integration/spark/elm-tests/src/AntiqueSSDataSource.elm
@@ -22,8 +22,8 @@ import CsvUtils exposing (..)
 import SparkTests.Types exposing (..)
 
 
-csvSSData : String
-csvSSData =
+csvData : String
+csvData =
     """name,ageOfItem,product,report
 item 3287,-1.0,Paintings,Report #1
 item 896539,-1.0,Paintings,
@@ -110,4 +110,4 @@ item 896578,101.0,HistoryWritings,
 
 antiqueSSDataSource : Result Error (List AntiqueSubset)
 antiqueSSDataSource =
-    Decode.decodeCsv Decode.FieldNamesFromFirstRow antiqueSSDecoder csvSSData
+    Decode.decodeCsv Decode.FieldNamesFromFirstRow antiqueSSDecoder csvData

--- a/tests-integration/spark/elm-tests/src/FooBoolDataSource.elm
+++ b/tests-integration/spark/elm-tests/src/FooBoolDataSource.elm
@@ -22,8 +22,8 @@ import CsvUtils exposing (..)
 import SparkTests.Types exposing (..)
 
 
-fooBoolData : String
-fooBoolData =
+csvData : String
+csvData =
     """foo
 True
 False
@@ -32,4 +32,4 @@ False
 
 fooBoolDataSource : Result Error (List FooBool)
 fooBoolDataSource =
-    Decode.decodeCsv Decode.FieldNamesFromFirstRow fooBoolDecoder fooBoolData
+    Decode.decodeCsv Decode.FieldNamesFromFirstRow fooBoolDecoder csvData

--- a/tests-integration/spark/elm-tests/src/FooFloatDataSource.elm
+++ b/tests-integration/spark/elm-tests/src/FooFloatDataSource.elm
@@ -22,8 +22,8 @@ import CsvUtils exposing (..)
 import SparkTests.Types exposing (..)
 
 
-fooFloatData : String
-fooFloatData =
+csvData : String
+csvData =
     """foo
 9.99
 8.13
@@ -39,4 +39,4 @@ fooFloatData =
 
 fooFloatDataSource : Result Error (List FooFloat)
 fooFloatDataSource =
-    Decode.decodeCsv Decode.FieldNamesFromFirstRow fooFloatDecoder fooFloatData
+    Decode.decodeCsv Decode.FieldNamesFromFirstRow fooFloatDecoder csvData

--- a/tests-integration/spark/elm-tests/src/FooIntDataSource.elm
+++ b/tests-integration/spark/elm-tests/src/FooIntDataSource.elm
@@ -22,8 +22,8 @@ import CsvUtils exposing (..)
 import SparkTests.Types exposing (..)
 
 
-fooIntData : String
-fooIntData =
+csvData : String
+csvData =
     """foo
 20
 2879
@@ -41,4 +41,4 @@ fooIntData =
 
 fooIntDataSource : Result Error (List FooInt)
 fooIntDataSource =
-    Decode.decodeCsv Decode.FieldNamesFromFirstRow fooIntDecoder fooIntData
+    Decode.decodeCsv Decode.FieldNamesFromFirstRow fooIntDecoder csvData

--- a/tests-integration/spark/elm-tests/src/FooMaybeBoolDataSource.elm
+++ b/tests-integration/spark/elm-tests/src/FooMaybeBoolDataSource.elm
@@ -22,8 +22,8 @@ import CsvUtils exposing (..)
 import SparkTests.Types exposing (..)
 
 
-fooMaybeBoolData : String
-fooMaybeBoolData =
+csvData : String
+csvData =
     """foo
 True
 False
@@ -33,4 +33,4 @@ False
 
 fooMaybeBoolDataSource : Result Error (List FooMaybeBool)
 fooMaybeBoolDataSource =
-    Decode.decodeCsv Decode.FieldNamesFromFirstRow fooBoolMaybeDecoder fooMaybeBoolData
+    Decode.decodeCsv Decode.FieldNamesFromFirstRow fooBoolMaybeDecoder csvData

--- a/tests-integration/spark/elm-tests/src/FooMaybeFloatDataSource.elm
+++ b/tests-integration/spark/elm-tests/src/FooMaybeFloatDataSource.elm
@@ -22,8 +22,8 @@ import CsvUtils exposing (..)
 import SparkTests.Types exposing (..)
 
 
-fooMaybeFloatData : String
-fooMaybeFloatData =
+csvData : String
+csvData =
     """foo
 9.99
 8.13
@@ -40,4 +40,4 @@ fooMaybeFloatData =
 
 fooMaybeFloatDataSource : Result Error (List FooMaybeFloat)
 fooMaybeFloatDataSource =
-    Decode.decodeCsv Decode.FieldNamesFromFirstRow fooFloatMaybeDecoder fooMaybeFloatData
+    Decode.decodeCsv Decode.FieldNamesFromFirstRow fooFloatMaybeDecoder csvData

--- a/tests-integration/spark/elm-tests/src/FooMaybeIntDataSource.elm
+++ b/tests-integration/spark/elm-tests/src/FooMaybeIntDataSource.elm
@@ -22,8 +22,8 @@ import CsvUtils exposing (..)
 import SparkTests.Types exposing (..)
 
 
-fooMaybeIntData : String
-fooMaybeIntData =
+csvData : String
+csvData =
     """foo
 20
 2879
@@ -42,4 +42,4 @@ fooMaybeIntData =
 
 fooMaybeIntDataSource : Result Error (List FooMaybeInt)
 fooMaybeIntDataSource =
-    Decode.decodeCsv Decode.FieldNamesFromFirstRow fooIntMaybeDecoder fooMaybeIntData
+    Decode.decodeCsv Decode.FieldNamesFromFirstRow fooIntMaybeDecoder csvData

--- a/tests-integration/spark/elm-tests/src/FooMaybeStringDataSource.elm
+++ b/tests-integration/spark/elm-tests/src/FooMaybeStringDataSource.elm
@@ -22,8 +22,8 @@ import CsvUtils exposing (..)
 import SparkTests.Types exposing (..)
 
 
-fooMaybeStringData : String
-fooMaybeStringData =
+csvData : String
+csvData =
     """foo
 bar
 cat
@@ -40,4 +40,4 @@ paper
 
 fooMaybeStringDataSource : Result Error (List FooMaybeString)
 fooMaybeStringDataSource =
-    Decode.decodeCsv Decode.FieldNamesFromFirstRow fooStringMaybeDecoder fooMaybeStringData
+    Decode.decodeCsv Decode.FieldNamesFromFirstRow fooStringMaybeDecoder csvData

--- a/tests-integration/spark/elm-tests/src/FooStringDataSource.elm
+++ b/tests-integration/spark/elm-tests/src/FooStringDataSource.elm
@@ -22,8 +22,8 @@ import CsvUtils exposing (..)
 import SparkTests.Types exposing (..)
 
 
-fooStringData : String
-fooStringData =
+csvData : String
+csvData =
     """foo
 bar
 cat
@@ -39,4 +39,4 @@ paper
 
 fooStringDataSource : Result Error (List FooString)
 fooStringDataSource =
-    Decode.decodeCsv Decode.FieldNamesFromFirstRow fooStringDecoder fooStringData
+    Decode.decodeCsv Decode.FieldNamesFromFirstRow fooStringDecoder csvData

--- a/tests-integration/spark/elm-tests/tests/GenerateAntiqueAgeData.elm
+++ b/tests-integration/spark/elm-tests/tests/GenerateAntiqueAgeData.elm
@@ -1,7 +1,7 @@
-module GenerateAgeData exposing (..)
+module GenerateAntiqueAgeData exposing (..)
 
 import Expect exposing (Expectation)
-import GenerateAntiqueTestData exposing (..)
+import GenerateAntiquesData exposing (..)
 import Test exposing (..)
 
 

--- a/tests-integration/spark/elm-tests/tests/GenerateAntiqueNameData.elm
+++ b/tests-integration/spark/elm-tests/tests/GenerateAntiqueNameData.elm
@@ -1,7 +1,7 @@
-module GenerateNameData exposing (..)
+module GenerateAntiqueNameData exposing (..)
 
 import Expect exposing (Expectation)
-import GenerateAntiqueTestData exposing (..)
+import GenerateAntiquesData exposing (..)
 import Test exposing (..)
 
 

--- a/tests-integration/spark/elm-tests/tests/GenerateAntiqueProductData.elm
+++ b/tests-integration/spark/elm-tests/tests/GenerateAntiqueProductData.elm
@@ -1,7 +1,7 @@
-module GenerateProductData exposing (..)
+module GenerateAntiqueProductData exposing (..)
 
 import Expect exposing (Expectation)
-import GenerateAntiqueTestData exposing (generateProduct)
+import GenerateAntiquesData exposing (generateProduct)
 import Test exposing (..)
 
 

--- a/tests-integration/spark/elm-tests/tests/GenerateAntiqueSSData.elm
+++ b/tests-integration/spark/elm-tests/tests/GenerateAntiqueSSData.elm
@@ -1,7 +1,7 @@
-module GenerateAntiqueSSTestData exposing (testASubsetDataGeneration)
+module GenerateAntiqueSSData exposing (testASubsetDataGeneration)
 
 import Expect exposing (Expectation)
-import GenerateAntiqueTestData exposing (..)
+import GenerateAntiquesData exposing (..)
 import Test exposing (..)
 
 

--- a/tests-integration/spark/elm-tests/tests/GenerateAntiquesData.elm
+++ b/tests-integration/spark/elm-tests/tests/GenerateAntiquesData.elm
@@ -15,7 +15,7 @@
 -}
 
 
-module GenerateAntiqueTestData exposing (..)
+module GenerateAntiquesData exposing (..)
 
 import Expect exposing (Expectation)
 import Test exposing (..)

--- a/tests-integration/spark/elm-tests/tests/GenerateFooBoolData.elm
+++ b/tests-integration/spark/elm-tests/tests/GenerateFooBoolData.elm
@@ -1,7 +1,7 @@
 module GenerateFooBoolData exposing (..)
 
 import Expect exposing (Expectation)
-import GenerateAntiqueTestData exposing (..)
+import GenerateAntiquesData exposing (..)
 import Test exposing (..)
 
 

--- a/tests-integration/spark/elm-tests/tests/GenerateFooFloatData.elm
+++ b/tests-integration/spark/elm-tests/tests/GenerateFooFloatData.elm
@@ -1,7 +1,7 @@
 module GenerateFooFloatData exposing (..)
 
 import Expect exposing (Expectation)
-import GenerateAntiqueTestData exposing (..)
+import GenerateAntiquesData exposing (..)
 import Test exposing (..)
 
 

--- a/tests-integration/spark/elm-tests/tests/GenerateFooIntData.elm
+++ b/tests-integration/spark/elm-tests/tests/GenerateFooIntData.elm
@@ -1,7 +1,7 @@
 module GenerateFooIntData exposing (..)
 
 import Expect exposing (Expectation)
-import GenerateAntiqueTestData exposing (..)
+import GenerateAntiquesData exposing (..)
 import Test exposing (..)
 
 

--- a/tests-integration/spark/elm-tests/tests/GenerateFooMaybeBoolData.elm
+++ b/tests-integration/spark/elm-tests/tests/GenerateFooMaybeBoolData.elm
@@ -1,7 +1,7 @@
 module GenerateFooMaybeBoolData exposing (..)
 
 import Expect exposing (Expectation)
-import GenerateAntiqueTestData exposing (..)
+import GenerateAntiquesData exposing (..)
 import Test exposing (..)
 
 

--- a/tests-integration/spark/elm-tests/tests/GenerateFooMaybeFloatData.elm
+++ b/tests-integration/spark/elm-tests/tests/GenerateFooMaybeFloatData.elm
@@ -1,7 +1,7 @@
 module GenerateFooMaybeFloatData exposing (..)
 
 import Expect exposing (Expectation)
-import GenerateAntiqueTestData exposing (..)
+import GenerateAntiquesData exposing (..)
 import Test exposing (..)
 
 

--- a/tests-integration/spark/elm-tests/tests/GenerateFooMaybeIntData.elm
+++ b/tests-integration/spark/elm-tests/tests/GenerateFooMaybeIntData.elm
@@ -1,7 +1,7 @@
 module GenerateFooMaybeIntData exposing (..)
 
 import Expect exposing (Expectation)
-import GenerateAntiqueTestData exposing (..)
+import GenerateAntiquesData exposing (..)
 import Test exposing (..)
 
 

--- a/tests-integration/spark/elm-tests/tests/GenerateFooMaybeStringData.elm
+++ b/tests-integration/spark/elm-tests/tests/GenerateFooMaybeStringData.elm
@@ -1,7 +1,7 @@
 module GenerateFooMaybeStringData exposing (..)
 
 import Expect exposing (Expectation)
-import GenerateAntiqueTestData exposing (..)
+import GenerateAntiquesData exposing (..)
 import Test exposing (..)
 
 

--- a/tests-integration/spark/elm-tests/tests/GenerateFooStringData.elm
+++ b/tests-integration/spark/elm-tests/tests/GenerateFooStringData.elm
@@ -1,7 +1,7 @@
 module GenerateFooStringData exposing (..)
 
 import Expect exposing (Expectation)
-import GenerateAntiqueTestData exposing (..)
+import GenerateAntiquesData exposing (..)
 import Test exposing (..)
 
 

--- a/tests-integration/spark/elm-tests/tests/create_csv_files.sh
+++ b/tests-integration/spark/elm-tests/tests/create_csv_files.sh
@@ -28,268 +28,47 @@ TEST_OUTPUT_DIR=$(mktemp -d -t elm-tests-XXXXXXXXXX)
 SPARK_TEST_DATA_DIR=../../test/src/spark_test_data
 mkdir -p "$SPARK_TEST_DATA_DIR"
 
+for genFile in Generate*.elm
+do
+    fileName="$(grep "Debug.log" "$genFile" | sed 's:[^"]\+"\([^"]\+\)".*:\1:g')"
+    testResultFile="$(mktemp --tmpdir="$TEST_OUTPUT_DIR")"
+    elm-test "$genFile" > "$testResultFile"
+    grep -m1 "$fileName" "$testResultFile" | sed -e 's?'"$fileName"': \["??' -e 's?",",?\n?g' -e 's?"]??' > "$SPARK_TEST_DATA_DIR/$fileName"
 
-# Generate the input test data as a CSV file of Antique records
-elm-test GenerateAntiqueTestData.elm > "$TEST_OUTPUT_DIR/generate_antique_test_data.txt"
-grep -m1 antiques_data.csv "$TEST_OUTPUT_DIR/generate_antique_test_data.txt" | sed -e 's?antiques_data.csv: \["??' -e 's?",",?\n?g' -e 's?"]??' > "$SPARK_TEST_DATA_DIR/antiques_data.csv"
+    echo -n '    """' | cat - "$SPARK_TEST_DATA_DIR/$fileName" > "$TEST_OUTPUT_DIR/$fileName.in"
+    echo '"""' >> "$TEST_OUTPUT_DIR/$fileName.in"
+    dataSourceName="$(echo "$genFile" | sed 's:Generate\(\w\+\).elm:\1Source.elm:')"
+    tempOutput="$(mktemp --tmpdir="$TEST_OUTPUT_DIR")"
+   
+    cat "../src/$dataSourceName" \
+        | sed -e '/^    """/,/^"""/d' \
+        | sed -e "/^csvData =/ r $TEST_OUTPUT_DIR/$fileName.in" > "$tempOutput"
+    cp "$tempOutput" "../src/$dataSourceName"
 
-elm-test GenerateAntiqueSSTestData.elm > "$TEST_OUTPUT_DIR/generate_antiqueSS_test_data.txt"
-grep -m1 antique_subset_data.csv "$TEST_OUTPUT_DIR/generate_antiqueSS_test_data.txt" | sed -e 's?antique_subset_data.csv: \["??' -e 's?",",?\n?g' -e 's?"]??' > "$SPARK_TEST_DATA_DIR/antique_subset_data.csv"
+done
 
-elm-test GenerateProductData.elm > "$TEST_OUTPUT_DIR/generate_product_data.txt"
-grep -m1 antique_product_data.csv "$TEST_OUTPUT_DIR/generate_product_data.txt" | sed -e 's?antique_product_data.csv: \["??' -e 's?",",?\n?g' -e 's?"]??' > "$SPARK_TEST_DATA_DIR/antique_product_data.csv"
-
-elm-test GenerateNameData.elm > "$TEST_OUTPUT_DIR/generate_name_data.txt"
-grep -m1 antique_name_data.csv "$TEST_OUTPUT_DIR/generate_name_data.txt" | sed -e 's?antique_name_data.csv: \["??' -e 's?",",?\n?g' -e 's?"]??' > "$SPARK_TEST_DATA_DIR/antique_name_data.csv"
-
-elm-test GenerateAgeData.elm > "$TEST_OUTPUT_DIR/generate_age_data.txt"
-grep -m1 antique_age_data.csv "$TEST_OUTPUT_DIR/generate_age_data.txt" | sed -e 's?antique_age_data.csv: \["??' -e 's?",",?\n?g' -e 's?"]??' > "$SPARK_TEST_DATA_DIR/antique_age_data.csv"
-
-elm-test GenerateFooBoolData.elm > "$TEST_OUTPUT_DIR/generate_foo_bool.txt"
-grep -m1 foo_bool_data.csv "$TEST_OUTPUT_DIR/generate_foo_bool.txt" | sed -e 's?foo_bool_data.csv: \["??' -e 's?",",?\n?g' -e 's?"]??' > "$SPARK_TEST_DATA_DIR/foo_bool_data.csv"
-
-elm-test GenerateFooIntData.elm > "$TEST_OUTPUT_DIR/generate_foo_int.txt"
-grep -m1 foo_int_data.csv "$TEST_OUTPUT_DIR/generate_foo_int.txt" | sed -e 's?foo_int_data.csv: \["??' -e 's?",",?\n?g' -e 's?"]??' > "$SPARK_TEST_DATA_DIR/foo_int_data.csv"
-
-elm-test GenerateFooFloatData.elm > "$TEST_OUTPUT_DIR/generate_foo_float.txt"
-grep -m1 foo_float_data.csv "$TEST_OUTPUT_DIR/generate_foo_float.txt" | sed -e 's?foo_float_data.csv: \["??' -e 's?",",?\n?g' -e 's?"]??' > "$SPARK_TEST_DATA_DIR/foo_float_data.csv"
-
-elm-test GenerateFooStringData.elm > "$TEST_OUTPUT_DIR/generate_foo_string.txt"
-grep -m1 foo_string_data.csv "$TEST_OUTPUT_DIR/generate_foo_string.txt" | sed -e 's?foo_string_data.csv: \["??' -e 's?",",?\n?g' -e 's?"]??' > "$SPARK_TEST_DATA_DIR/foo_string_data.csv"
-
-elm-test GenerateFooMaybeStringData.elm > "$TEST_OUTPUT_DIR/generate_foo_maybe_string.txt"
-grep -m1 foo_maybe_string_data.csv "$TEST_OUTPUT_DIR/generate_foo_maybe_string.txt" | sed -e 's?foo_maybe_string_data.csv: \["??' -e 's?",",?\n?g' -e 's?"]??' > "$SPARK_TEST_DATA_DIR/foo_maybe_string_data.csv"
-
-elm-test GenerateFooMaybeIntData.elm > "$TEST_OUTPUT_DIR/generate_foo_maybe_int.txt"
-grep -m1 foo_maybe_int_data.csv "$TEST_OUTPUT_DIR/generate_foo_maybe_int.txt" | sed -e 's?foo_maybe_int_data.csv: \["??' -e 's?",",?\n?g' -e 's?"]??' > "$SPARK_TEST_DATA_DIR/foo_maybe_int_data.csv"
-
-elm-test GenerateFooMaybeFloatData.elm > "$TEST_OUTPUT_DIR/generate_foo_maybe_float.txt"
-grep -m1 foo_maybe_float_data.csv "$TEST_OUTPUT_DIR/generate_foo_maybe_float.txt" | sed -e 's?foo_maybe_float_data.csv: \["??' -e 's?",",?\n?g' -e 's?"]??' > "$SPARK_TEST_DATA_DIR/foo_maybe_float_data.csv"
-
-elm-test GenerateFooMaybeBoolData.elm > "$TEST_OUTPUT_DIR/generate_foo_maybe_bool.txt"
-grep -m1 foo_maybe_bool_data.csv "$TEST_OUTPUT_DIR/generate_foo_maybe_bool.txt" | sed -e 's?foo_maybe_bool_data.csv: \["??' -e 's?",",?\n?g' -e 's?"]??' > "$SPARK_TEST_DATA_DIR/foo_maybe_bool_data.csv"
-
-# Add Elm triple quotes around the CSV data
-echo -n '    """' | cat - "$SPARK_TEST_DATA_DIR/antiques_data.csv" > "$TEST_OUTPUT_DIR/antiques_data.csv.in"
-echo '"""' >> "$TEST_OUTPUT_DIR/antiques_data.csv.in"
-
-echo -n '    """' | cat - "$SPARK_TEST_DATA_DIR/antique_subset_data.csv" > "$TEST_OUTPUT_DIR/antique_subset_data.csv.in"
-echo '"""' >> "$TEST_OUTPUT_DIR/antique_subset_data.csv.in"
-
-echo -n '    """' | cat - "$SPARK_TEST_DATA_DIR/antique_product_data.csv" > "$TEST_OUTPUT_DIR/antique_product_data.csv.in"
-echo '"""' >> "$TEST_OUTPUT_DIR/antique_product_data.csv.in"
-
-echo -n '    """' | cat - "$SPARK_TEST_DATA_DIR/antique_name_data.csv" > "$TEST_OUTPUT_DIR/antique_name_data.csv.in"
-echo '"""' >> "$TEST_OUTPUT_DIR/antique_name_data.csv.in"
-
-echo -n '    """' | cat - "$SPARK_TEST_DATA_DIR/antique_age_data.csv" > "$TEST_OUTPUT_DIR/antique_age_data.csv.in"
-echo '"""' >> "$TEST_OUTPUT_DIR/antique_age_data.csv.in"
-
-echo -n '    """' | cat - "$SPARK_TEST_DATA_DIR/foo_float_data.csv" > "$TEST_OUTPUT_DIR/foo_float_data.csv.in"
-echo '"""' >> "$TEST_OUTPUT_DIR/foo_float_data.csv.in"
-
-echo -n '    """' | cat - "$SPARK_TEST_DATA_DIR/foo_int_data.csv" > "$TEST_OUTPUT_DIR/foo_int_data.csv.in"
-echo '"""' >> "$TEST_OUTPUT_DIR/foo_int_data.csv.in"
-
-echo -n '    """' | cat - "$SPARK_TEST_DATA_DIR/foo_bool_data.csv" > "$TEST_OUTPUT_DIR/foo_bool_data.csv.in"
-echo '"""' >> "$TEST_OUTPUT_DIR/foo_bool_data.csv.in"
-
-echo -n '    """' | cat - "$SPARK_TEST_DATA_DIR/foo_string_data.csv" > "$TEST_OUTPUT_DIR/foo_string_data.csv.in"
-echo '"""' >> "$TEST_OUTPUT_DIR/foo_string_data.csv.in"
-
-echo -n '    """' | cat - "$SPARK_TEST_DATA_DIR/foo_maybe_string_data.csv" > "$TEST_OUTPUT_DIR/foo_maybe_string_data.csv.in"
-echo '"""' >> "$TEST_OUTPUT_DIR/foo_maybe_string_data.csv.in"
-
-echo -n '    """' | cat - "$SPARK_TEST_DATA_DIR/foo_maybe_int_data.csv" > "$TEST_OUTPUT_DIR/foo_maybe_int_data.csv.in"
-echo '"""' >> "$TEST_OUTPUT_DIR/foo_maybe_int_data.csv.in"
-
-echo -n '    """' | cat - "$SPARK_TEST_DATA_DIR/foo_maybe_bool_data.csv" > "$TEST_OUTPUT_DIR/foo_maybe_bool_data.csv.in"
-echo '"""' >> "$TEST_OUTPUT_DIR/foo_maybe_bool_data.csv.in"
-
-echo -n '    """' | cat - "$SPARK_TEST_DATA_DIR/foo_maybe_float_data.csv" > "$TEST_OUTPUT_DIR/foo_maybe_float_data.csv.in"
-echo '"""' >> "$TEST_OUTPUT_DIR/foo_maybe_float_data.csv.in"
-
-# Update src/AntiquesDataSource.elm source with the newly generated Antiques CSV data
-cat ../src/AntiquesDataSource.elm \
-    | sed -e '/^    """/,/^"""/d' \
-    | sed -e "/^csvData =/ r $TEST_OUTPUT_DIR/antiques_data.csv.in" > "$TEST_OUTPUT_DIR/Temp.elm"
-cp "$TEST_OUTPUT_DIR/Temp.elm" ../src/AntiquesDataSource.elm
-
-cat ../src/AntiqueSSDataSource.elm \
-    | sed -e '/^    """/,/^"""/d' \
-    | sed -e "/^csvSSData =/ r $TEST_OUTPUT_DIR/antique_subset_data.csv.in" > "$TEST_OUTPUT_DIR/Temp2.elm"
-cp "$TEST_OUTPUT_DIR/Temp2.elm" ../src/AntiqueSSDataSource.elm
-
-cat ../src/AntiqueProductDataSource.elm \
-    | sed -e '/^    """/,/^"""/d' \
-    | sed -e "/^csvProductData =/ r $TEST_OUTPUT_DIR/antique_product_data.csv.in" > "$TEST_OUTPUT_DIR/Temp3.elm"
-cp "$TEST_OUTPUT_DIR/Temp3.elm" ../src/AntiqueProductDataSource.elm
-
-cat ../src/AntiqueNameDataSource.elm \
-    | sed -e '/^    """/,/^"""/d' \
-    | sed -e "/^csvNameData =/ r $TEST_OUTPUT_DIR/antique_name_data.csv.in" > "$TEST_OUTPUT_DIR/Temp4.elm"
-cp "$TEST_OUTPUT_DIR/Temp4.elm" ../src/AntiqueNameDataSource.elm
-
-cat ../src/AntiqueAgeDataSource.elm \
-    | sed -e '/^    """/,/^"""/d' \
-    | sed -e "/^csvAgeData =/ r $TEST_OUTPUT_DIR/antique_age_data.csv.in" > "$TEST_OUTPUT_DIR/Temp5.elm"
-cp "$TEST_OUTPUT_DIR/Temp5.elm" ../src/AntiqueAgeDataSource.elm
-
-cat ../src/FooIntDataSource.elm \
-    | sed -e '/^    """/,/^"""/d' \
-    | sed -e "/^fooIntData =/ r $TEST_OUTPUT_DIR/foo_int_data.csv.in" > "$TEST_OUTPUT_DIR/Temp6.elm"
-cp "$TEST_OUTPUT_DIR/Temp6.elm" ../src/FooIntDataSource.elm
-
-cat ../src/FooFloatDataSource.elm \
-    | sed -e '/^    """/,/^"""/d' \
-    | sed -e "/^fooFloatData =/ r $TEST_OUTPUT_DIR/foo_float_data.csv.in" > "$TEST_OUTPUT_DIR/Temp7.elm"
-cp "$TEST_OUTPUT_DIR/Temp7.elm" ../src/FooFloatDataSource.elm
-
-cat ../src/FooStringDataSource.elm \
-    | sed -e '/^    """/,/^"""/d' \
-    | sed -e "/^fooStringData =/ r $TEST_OUTPUT_DIR/foo_string_data.csv.in" > "$TEST_OUTPUT_DIR/Temp8.elm"
-cp "$TEST_OUTPUT_DIR/Temp8.elm" ../src/FooStringDataSource.elm
-
-cat ../src/FooBoolDataSource.elm \
-    | sed -e '/^    """/,/^"""/d' \
-    | sed -e "/^fooBoolData =/ r $TEST_OUTPUT_DIR/foo_bool_data.csv.in" > "$TEST_OUTPUT_DIR/Temp9.elm"
-cp "$TEST_OUTPUT_DIR/Temp9.elm" ../src/FooBoolDataSource.elm
-
-cat ../src/FooMaybeIntDataSource.elm \
-    | sed -e '/^    """/,/^"""/d' \
-    | sed -e "/^fooMaybeIntData =/ r $TEST_OUTPUT_DIR/foo_maybe_int_data.csv.in" > "$TEST_OUTPUT_DIR/Temp10.elm"
-cp "$TEST_OUTPUT_DIR/Temp10.elm" ../src/FooMaybeIntDataSource.elm
-
-cat ../src/FooMaybeFloatDataSource.elm \
-    | sed -e '/^    """/,/^"""/d' \
-    | sed -e "/^fooMaybeFloatData =/ r $TEST_OUTPUT_DIR/foo_maybe_float_data.csv.in" > "$TEST_OUTPUT_DIR/Temp11.elm"
-cp "$TEST_OUTPUT_DIR/Temp11.elm" ../src/FooMaybeFloatDataSource.elm
-
-cat ../src/FooMaybeStringDataSource.elm \
-    | sed -e '/^    """/,/^"""/d' \
-    | sed -e "/^fooMaybeStringData =/ r $TEST_OUTPUT_DIR/foo_maybe_string_data.csv.in" > "$TEST_OUTPUT_DIR/Temp12.elm"
-cp "$TEST_OUTPUT_DIR/Temp12.elm" ../src/FooMaybeStringDataSource.elm
-
-cat ../src/FooMaybeBoolDataSource.elm \
-    | sed -e '/^    """/,/^"""/d' \
-    | sed -e "/^fooMaybeBoolData =/ r $TEST_OUTPUT_DIR/foo_maybe_bool_data.csv.in" > "$TEST_OUTPUT_DIR/Temp13.elm"
-cp "$TEST_OUTPUT_DIR/Temp13.elm" ../src/FooMaybeBoolDataSource.elm
 
 elmTestOutputToCsv () {
+
     elm-test "$1" > "$TEST_OUTPUT_DIR/$2.txt"
     grep -m1 "expected_results_$2.csv" "$TEST_OUTPUT_DIR/$2.txt" |sed -e "s?expected_results_$2.csv: Ok \"??" -e 's?"??g' -e 's?\\r\\n?\n?g' \
     > "$SPARK_TEST_DATA_DIR/expected_results_$2.csv"
 }
 
-
-# Run the is_item_vintage test and save the corresponding CSV file
-elmTestOutputToCsv "TestIsItemVintage.elm" "is_item_vintage"
-
-# Run the is_item_worth_millions test and save the corresponding CSV file
-elmTestOutputToCsv "TestIsItemWorthMillions.elm" "is_item_worth_millions"
-
-# Run the is_item_worth_thousands test and save the corresponding CSV file
-elmTestOutputToCsv "TestIsItemWorthThousands.elm" "is_item_worth_thousands"
-
-# Run the is_item_antique test and save the corresponding CSV file
-elmTestOutputToCsv "TestIsItemAntique.elm" "is_item_antique"
-
-# Run the seize_item test and save the corresponding CSV file
-elmTestOutputToCsv "TestSeizeItem.elm" "seize_item"
+skippedFiles="TestAntiqueSSFilter.elm  
+TestAntiqueSSMapAndFilter.elm
+TestAntiqueSSMapAndFilter2.elm 
+TestAntiqueSSMapAndFilter3.elm"
 
 
-# Run the christmas_bonanza_15percent_priceRange test and save the corresponding CSV file
-# This one is slightly different from the others because it manually reformats the output into csv
-elm-test "TestChristmasBonanza.elm" > "$TEST_OUTPUT_DIR/christmas_bonanza_15percent_priceRange.txt"
-grep -m1 "expected_results_christmas_bonanza_15percent_priceRange.csv" "$TEST_OUTPUT_DIR/christmas_bonanza_15percent_priceRange.txt" | sed -e "s?expected_results_christmas_bonanza_15percent_priceRange.csv: Ok (??" -e 's?)??g' -e 'i minimum,maximum' \
-> "$SPARK_TEST_DATA_DIR/expected_results_christmas_bonanza_15percent_priceRange.csv"
+for fileName in Test*.elm
+do
 
-elmTestOutputToCsv "TestAggregateAverage.elm" "testAggregateAverage"
-elmTestOutputToCsv "TestAggregateCount.elm" "testAggregateCount"
-elmTestOutputToCsv "TestAggregateFilterAll.elm" "testAggregateFilterAll"
-elmTestOutputToCsv "TestAggregateFilterOneCount.elm" "testAggregateFilterOneCount"
-elmTestOutputToCsv "TestAggregateFilterOneMin.elm" "testAggregateFilterOneMin"
-elmTestOutputToCsv "TestAggregateMaximum.elm" "testAggregateMaximum"
-elmTestOutputToCsv "TestAggregateMinimum.elm" "testAggregateMinimum"
-elmTestOutputToCsv "TestAggregateSum.elm" "testAggregateSum"
-
-elmTestOutputToCsv "TestAntiqueSSCaseString.elm" "testCaseString"
-
-elmTestOutputToCsv "TestAntiqueSSCaseEnum.elm" "testCaseEnum"
-
-elmTestOutputToCsv "TestAntiqueSSFrom.elm" "testFrom"
-
-elmTestOutputToCsv "TestAntiqueSSWhere1.elm" "testWhere1"
-
-elmTestOutputToCsv "TestAntiqueSSWhere2.elm" "testWhere2"
-
-elmTestOutputToCsv "TestAntiqueSSWhere3.elm" "testWhere3"
-
-elmTestOutputToCsv "TestAntiqueSSSelect1.elm" "testSelect1" 
-
-elmTestOutputToCsv "TestAntiqueSSSelect3.elm" "testSelect3"
-
-elmTestOutputToCsv "TestAntiqueSSSelect4.elm" "testSelect4"
-
-###########################elmTestOutputToCsv "TestAntiqueSSFilter.elm" "testFilter"  ##FILTERFN DIVIDE BY ZERO ERROR
-
-elmTestOutputToCsv "TestAntiqueSSFilter2.elm" "testFilter2"
-
-###########################elmTestOutputToCsv "TestAntiqueSSMapAndFilter.elm" "testMapAndFilter" ##FILTERFN DIVIDE BY ZERO ERROR
-
-###########################elmTestOutputToCsv "TestAntiqueSSMapAndFilter2.elm" "testMapAndFilter2" ##FILTERFN DIVIDE BY ZERO ERROR
-
-###########################elmTestOutputToCsv "TestAntiqueSSMapAndFilter3.elm" "testMapAndFilter3" ##FILTERFN DIVIDE BY ZERO ERROR
-
-elmTestOutputToCsv "TestAntiqueSSListMaximum.elm" "testListMaximum"
-
-elmTestOutputToCsv "TestAntiqueSSListMinimum.elm" "testListMinimum"
-
-elmTestOutputToCsv "TestAntiqueSSNameMaximum.elm" "testNameMaximum" 
-
-elmTestOutputToCsv "TestAntiqueSSBadAnnotation.elm" "testBadAnnotation"
-
-elmTestOutputToCsv "TestAntiqueSSLetBinding.elm" "testLetBinding"
-
-elmTestOutputToCsv "TestAntiqueSSListSum.elm" "testListSum"
-
-elmTestOutputToCsv "TestAntiqueSSListLength.elm" "testListLength"
-
-elmTestOutputToCsv "TestEnumListMember.elm" "testEnumListMember"
-
-elmTestOutputToCsv "TestStringListMember.elm" "testStringListMember"
-
-elmTestOutputToCsv "TestIntListMember.elm" "testIntListMember"
-
-elmTestOutputToCsv "TestEnum.elm" "testEnum"
-
-elmTestOutputToCsv "TestCaseInt.elm" "testCaseInt"
-
-elmTestOutputToCsv "TestCaseBool.elm" "testCaseBool"
-
-elmTestOutputToCsv "TestString.elm" "testString"
-
-elmTestOutputToCsv "TestFloat.elm" "testFloat"
-
-elmTestOutputToCsv "TestInt.elm" "testInt"
-
-elmTestOutputToCsv "TestBool.elm" "testBool"
-
-elmTestOutputToCsv "TestMaybeString.elm" "testMaybeString"
-
-elmTestOutputToCsv "TestMaybeFloat.elm" "testMaybeFloat"
-
-elmTestOutputToCsv "TestMaybeInt.elm" "testMaybeInt"
-
-elmTestOutputToCsv "TestMaybeBoolConditional.elm" "testMaybeBoolConditional"
-
-elmTestOutputToCsv "TestMaybeBoolConditionalNull.elm" "testMaybeBoolConditionalNull"
-
-elmTestOutputToCsv "TestMaybeBoolConditionalNotNull.elm" "testMaybeBoolConditionalNotNull"
-
-elmTestOutputToCsv "TestMaybeMapDefault.elm" "testMaybeMapDefault"
-
-elmTestOutputToCsv "TestReturnListRecords.elm" "testReturnListRecords"
-elmTestOutputToCsv "TestReturnValue1.elm" "testReturnValue1"
-elmTestOutputToCsv "TestReturnValue2.elm" "testReturnValue2"
-elmTestOutputToCsv "TestReturnMaybe.elm" "testReturnMaybe"
+    if grep -q "$fileName" <<< "$skippedFiles"
+    then 
+    continue
+    fi
+    testName="$(grep "executeTest" "$fileName" | grep -v '^import' | sed 's:[^"]\+"\([^"]\+\)".*:\1:g')"
+    elmTestOutputToCsv $fileName $testName
+    
+done

--- a/tests-integration/spark/test/src/spark_test_data/expected_results_christmas_bonanza_15percent_priceRange.csv
+++ b/tests-integration/spark/test/src/spark_test_data/expected_results_christmas_bonanza_15percent_priceRange.csv
@@ -1,2 +1,1 @@
-minimum,maximum
-0,150000
+expected_results_christmas_bonanza_15percent_priceRange.csv: Ok (0,150000)


### PR DESCRIPTION
Replaced the need for manual tests generators in the create_csv_files.sh file with loops that iterate over Test*.elm and Generate*.elm files in the "tests-integration/spark/elm-tests/tests" directory, execute the test data and create output files.
Updated the documentation for spark tests.
Addressed issue #866




# Terms

> THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE TERMS OF THE CCLA DATED 2017-11-07 WITH FINOS/LINUX FOUNDATION (FORMERLY THE SYMPHONY SOFTWARE FOUNDATION CCLA).
>
> THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
