### PR TITLE
Draft: Spark: Support Morphir Aggregation grouped by multiple keys

### DIFF
--- a/tests-integration/spark/elm-tests/tests/TestAggregateMultiGroup.elm
+++ b/tests-integration/spark/elm-tests/tests/TestAggregateMultiGroup.elm
@@ -1,0 +1,48 @@
+{-
+   Copyright 2022 Morgan Stanley
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+-}
+
+
+module TestAggregateMultiGroup exposing (..)
+
+import AntiquesDataSource exposing (antiquesDataSource)
+import Csv.Encode as Encode exposing (..)
+import CsvUtils exposing (antiqueEncoder)
+import SparkTests.AggregationTests exposing (testAggregateMultiGroup)
+import SparkTests.DataDefinition.Persistence.Income.AntiqueShop exposing (Product(..), productToString)
+import SparkTests.DataDefinition.Field.Category exposing (Category(..), categoryToString)
+import Test exposing (Test)
+import TestUtils exposing (executeTest)
+
+
+encodeResult : List { category : Maybe Category, product : Product, count : Float } -> String
+encodeResult results =
+    results
+        |> Encode.encode
+            { encoder =
+                Encode.withFieldNames
+                    (\result ->
+                        [ ( "category", categoryToString result.category )
+                        , ( "product", productToString result.product )
+                        , ( "count", String.fromFloat result.count )
+                        ]
+                    )
+            , fieldSeparator = ','
+            }
+
+
+testAggregate : Test
+testAggregate =
+    executeTest "testAggregateMultiGroup" antiquesDataSource testAggregateMultiGroup encodeResult

--- a/tests-integration/spark/model/src/SparkTests/AggregationTests.elm
+++ b/tests-integration/spark/model/src/SparkTests/AggregationTests.elm
@@ -1,7 +1,9 @@
 module SparkTests.AggregationTests exposing (..)
 
 import Morphir.SDK.Aggregate exposing (aggregate, averageOf, count, groupBy, maximumOf, minimumOf, sumOf, withFilter)
+import Morphir.SDK.Key exposing (key2)
 import SparkTests.DataDefinition.Persistence.Income.AntiqueShop exposing (Antique, Product)
+import SparkTests.DataDefinition.Field.Category exposing (Category)
 
 
 testAggregateSum : List Antique -> List { product : Product, sum : Float }
@@ -112,6 +114,18 @@ testAggregateRenameKey antiques =
         |> aggregate
             (\key inputs ->
                 { itemType = key
+                , count = inputs count
+                }
+            )
+
+testAggregateMultiGroup : List Antique -> List { category : Maybe Category, product : Product, count : Float }
+testAggregateMultiGroup antiques =
+    antiques
+        |> groupBy (key2 .category .product)
+        |> aggregate
+            (\(categoryKey, productKey) inputs ->
+                { category = categoryKey
+                , product = productKey
                 , count = inputs count
                 }
             )


### PR DESCRIPTION
This PR currently just contains an example and elm test to exercise Morphir SDK aggregation by multiple keys.



# Terms

> THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE TERMS OF THE CCLA DATED 2017-11-07 WITH FINOS/LINUX FOUNDATION (FORMERLY THE SYMPHONY SOFTWARE FOUNDATION CCLA).
>
> THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
