### PR TITLE
Make sure type inference finds local private constructors

### DIFF
--- a/src/Morphir/IR/Module.elm
+++ b/src/Morphir/IR/Module.elm
@@ -115,10 +115,11 @@ A module contains types and values which is represented by two field in this typ
   - values: a dictionary of local name to access controlled value specification.
 
 Type variables ta and va refer to type annotation and value annotation
+
 -}
 type alias Definition ta va =
     { types : Dict Name (AccessControlled (Documented (Type.Definition ta)))
-    , values : Dict Name (AccessControlled (Documented  (Value.Definition ta va)))
+    , values : Dict Name (AccessControlled (Documented (Value.Definition ta va)))
     }
 
 
@@ -205,7 +206,7 @@ definitionToSpecificationWithPrivate def =
                     ( path
                     , accessControlledType
                         |> withPrivateAccess
-                        |> Documented.map Type.definitionToSpecification
+                        |> Documented.map Type.definitionToSpecificationWithPrivate
                     )
                 )
             |> Dict.fromList
@@ -273,7 +274,7 @@ mapDefinitionAttributes tf vf def =
             |> Dict.map
                 (\_ valueDef ->
                     AccessControlled valueDef.access
-                        ( valueDef.value |> Documented.map (Value.mapDefinitionAttributes tf vf))
+                        (valueDef.value |> Documented.map (Value.mapDefinitionAttributes tf vf))
                 )
         )
 

--- a/src/Morphir/IR/Type.elm
+++ b/src/Morphir/IR/Type.elm
@@ -20,7 +20,7 @@ module Morphir.IR.Type exposing
     , variable, reference, tuple, record, extensibleRecord, function, unit
     , Field, mapFieldName, mapFieldType
     , Specification(..), typeAliasSpecification, opaqueTypeSpecification, customTypeSpecification
-    , Definition(..), typeAliasDefinition, customTypeDefinition, definitionToSpecification
+    , Definition(..), typeAliasDefinition, customTypeDefinition, definitionToSpecification, definitionToSpecificationWithPrivate
     , Constructors, Constructor, ConstructorArgs
     , mapTypeAttributes, mapSpecificationAttributes, mapDefinitionAttributes, mapDefinition, typeAttributes
     , eraseAttributes, collectVariables, collectReferences, collectReferencesFromDefintion, substituteTypeVariables, toString
@@ -114,7 +114,7 @@ Here is the full definition for reference:
 
 # Definition
 
-@docs Definition, typeAliasDefinition, customTypeDefinition, definitionToSpecification
+@docs Definition, typeAliasDefinition, customTypeDefinition, definitionToSpecification, definitionToSpecificationWithPrivate
 
 
 # Constructors
@@ -131,7 +131,7 @@ Here is the full definition for reference:
 -}
 
 import Dict exposing (Dict)
-import Morphir.IR.AccessControlled as AccessControlled exposing (AccessControlled, withPublicAccess)
+import Morphir.IR.AccessControlled as AccessControlled exposing (AccessControlled, withPrivateAccess, withPublicAccess)
 import Morphir.IR.FQName exposing (FQName)
 import Morphir.IR.Name as Name exposing (Name)
 import Morphir.IR.Path as Path
@@ -269,6 +269,19 @@ definitionToSpecification def =
 
                 Nothing ->
                     OpaqueTypeSpecification params
+
+
+{-| -}
+definitionToSpecificationWithPrivate : Definition a -> Specification a
+definitionToSpecificationWithPrivate def =
+    case def of
+        TypeAliasDefinition params exp ->
+            TypeAliasSpecification params exp
+
+        CustomTypeDefinition params accessControlledCtors ->
+            accessControlledCtors
+                |> withPrivateAccess
+                |> CustomTypeSpecification params
 
 
 {-| -}

--- a/tests-integration/reference-model/src/Morphir/Reference/Model/Issues/Issue962.elm
+++ b/tests-integration/reference-model/src/Morphir/Reference/Model/Issues/Issue962.elm
@@ -1,0 +1,11 @@
+module Morphir.Reference.Model.Issues.Issue962 exposing (Foo, test)
+
+
+type Foo
+    = Foo String Bool
+
+
+test foo =
+    case foo of
+        Foo s _ ->
+            s


### PR DESCRIPTION
closes #962




# Terms

> THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE TERMS OF THE CCLA DATED 2017-11-07 WITH FINOS/LINUX FOUNDATION (FORMERLY THE SYMPHONY SOFTWARE FOUNDATION CCLA).
>
> THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
