### PR TITLE
Added fix for custom types which has constructor with no arguments

### DIFF
--- a/src/Morphir/Scala/AST.elm
+++ b/src/Morphir/Scala/AST.elm
@@ -190,6 +190,7 @@ type MemberDecl
 type Type
     = TypeVar Name
     | TypeRef Path Name
+    | TypeOfValue Path
     | TypeApply Type (List Type)
     | TypeParametrized Type (List Type) Type
     | TupleType (List Type)

--- a/src/Morphir/Scala/Feature/Core.elm
+++ b/src/Morphir/Scala/Feature/Core.elm
@@ -274,7 +274,7 @@ mapCustomTypeDefinition currentPackagePath currentModulePath moduleDef typeName 
         companionObjectVal name =
             let
                 companionTypeRef =
-                    Scala.TypeRef (parentPackagePath ++ [ parentTraitName, name |> Name.toTitleCase ]) "type"
+                    Scala.TypeOfValue (parentPackagePath ++ [ parentTraitName, name |> Name.toTitleCase ])
             in
             Scala.ValueDecl
                 { modifiers = []
@@ -338,11 +338,12 @@ mapCustomTypeDefinition currentPackagePath currentModulePath moduleDef typeName 
                     ]
 
                 else if List.length ctorArgs == 0 then
+                    -- This handles constructors with no arguments. We explicitly create a type alias to represent the type
                     [ Scala.withoutAnnotation
                         (Scala.TypeAlias
                             { alias = typeName |> Name.toTitleCase
                             , typeArgs = []
-                            , tpe = Scala.TypeRef [ typeName |> Name.toTitleCase ] "type"
+                            , tpe = Scala.TypeOfValue [ typeName |> Name.toTitleCase ]
                             }
                         )
                     , Scala.withoutAnnotation

--- a/src/Morphir/Scala/Feature/Core.elm
+++ b/src/Morphir/Scala/Feature/Core.elm
@@ -337,6 +337,20 @@ mapCustomTypeDefinition currentPackagePath currentModulePath moduleDef typeName 
                         )
                     ]
 
+                else if List.length ctorArgs == 0 then
+                    [ Scala.withoutAnnotation
+                        (Scala.TypeAlias
+                            { alias = typeName |> Name.toTitleCase
+                            , typeArgs = []
+                            , tpe = Scala.TypeRef [ typeName |> Name.toTitleCase ] "type"
+                            }
+                        )
+                    , Scala.withoutAnnotation
+                        (Scala.MemberTypeDecl
+                            (caseClass ctorName ctorArgs [])
+                        )
+                    ]
+
                 else
                     [ Scala.withoutAnnotation
                         (Scala.MemberTypeDecl

--- a/src/Morphir/Scala/PrettyPrinter.elm
+++ b/src/Morphir/Scala/PrettyPrinter.elm
@@ -351,6 +351,9 @@ mapType opt tpe =
         TypeRef path name ->
             dotSep (path ++ [ name ])
 
+        TypeOfValue path ->
+            dotSep (path ++ [ "type " ])
+
         TypeApply ctor args ->
             mapType opt ctor
                 ++ "["


### PR DESCRIPTION


# Terms

> THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE TERMS OF THE CCLA DATED 2017-11-07 WITH FINOS/LINUX FOUNDATION (FORMERLY THE SYMPHONY SOFTWARE FOUNDATION CCLA).
>
> THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
