### PR TITLE
Fix IR portability limitations

### DIFF
--- a/morphir.json
+++ b/morphir.json
@@ -2,15 +2,6 @@
     "name": "Morphir",
     "sourceDirectory": "src",
     "exposedModules": [
-        "IR.Name",
-        "IR.Path",
-        "IR.QName",
-        "IR.FQName",
-        "IR.AccessControlled",
-        "IR.Type",
-        "IR.Value",
-        "IR.Module",
-        "IR.Package",
         "IR.Distribution"
     ]
 }

--- a/src/Morphir/Elm/Frontend.elm
+++ b/src/Morphir/Elm/Frontend.elm
@@ -1419,7 +1419,7 @@ mapOperator sourceLocation op =
             Ok <| SDKBasics.greaterThanOrEqual sourceLocation
 
         "++" ->
-            Err [ NotSupported sourceLocation "The ++ operator is currently not supported. Please use String.append or List.append. See docs/error-append-not-supported.md" ]
+            Ok <| SDKBasics.append sourceLocation
 
         "+" ->
             Ok <| SDKBasics.add sourceLocation

--- a/src/Morphir/Elm/IncrementalFrontend/Mapper.elm
+++ b/src/Morphir/Elm/IncrementalFrontend/Mapper.elm
@@ -668,11 +668,7 @@ mapOperator moduleName range op =
             Ok <| SDKBasics.greaterThanOrEqual defaultValueAttribute
 
         "++" ->
-            Err
-                [ NotSupported
-                    (SourceLocation moduleName range)
-                    "The ++ operator is currently not supported. Please use String.append or List.append. See docs/error-append-not-supported.md"
-                ]
+            Ok <| SDKBasics.append defaultValueAttribute
 
         "+" ->
             Ok <| SDKBasics.add defaultValueAttribute

--- a/src/Morphir/Elm/IncrementalResolve.elm
+++ b/src/Morphir/Elm/IncrementalResolve.elm
@@ -257,35 +257,35 @@ resolveImports repo imports =
 
                 _ ->
                     resolvedImports
+
         moduleSpecToVisibleNames : Module.Specification () -> VisibleNames
         moduleSpecToVisibleNames moduleSpec =
-            { types = 
+            { types =
                 moduleSpec.types |> Dict.keys |> Set.fromList
-            , constructors = 
-                moduleSpec.types 
+            , constructors =
+                moduleSpec.types
                     |> Dict.toList
                     |> List.concatMap
                         (\( _, typeSpec ) ->
                             case typeSpec.value of
                                 Type.CustomTypeSpecification _ constructors ->
-                                    constructors |> Dict.keys 
+                                    constructors |> Dict.keys
 
                                 _ ->
-                                    []   
+                                    []
                         )
-                    |> Set.fromList    
-            , values = 
+                    |> Set.fromList
+            , values =
                 moduleSpec.values |> Dict.keys |> Set.fromList
-            }    
+            }
 
-        addModuleSpec :  QualifiedModuleName -> Module.Specification () -> ResolvedImports -> ResolvedImports
+        addModuleSpec : QualifiedModuleName -> Module.Specification () -> ResolvedImports -> ResolvedImports
         addModuleSpec qualifiedModuleName moduleSpec resolvedImports =
-                { resolvedImports
-                        | visibleNamesByModuleName =
-                            resolvedImports.visibleNamesByModuleName
-                                |> Dict.update qualifiedModuleName (always (Just (moduleSpecToVisibleNames moduleSpec)))
-
-                }        
+            { resolvedImports
+                | visibleNamesByModuleName =
+                    resolvedImports.visibleNamesByModuleName
+                        |> Dict.update qualifiedModuleName (always (Just (moduleSpecToVisibleNames moduleSpec)))
+            }
 
         addLocalName : KindOfName -> QualifiedModuleName -> Name -> ResolvedImports -> ResolvedImports
         addLocalName kindOfName qualifiedModuleName name resolvedImports =
@@ -382,7 +382,7 @@ resolveImports repo imports =
                                                                     resolvedImportsSoFar
                                                                         |> Result.map
                                                                             (\soFar ->
-                                                                                soFar 
+                                                                                soFar
                                                                                     |> addLocalName Type qualifiedModuleName typeName
                                                                                     |> addLocalName Constructor qualifiedModuleName typeName
                                                                             )

--- a/src/Morphir/IR/SDK/Basics.elm
+++ b/src/Morphir/IR/SDK/Basics.elm
@@ -15,7 +15,7 @@
 -}
 
 
-module Morphir.IR.SDK.Basics exposing (add, and, boolType, composeLeft, composeRight, divide, encodeOrder, equal, floatType, greaterThan, greaterThanOrEqual, intType, integerDivide, isNumber, lessThan, lessThanOrEqual, moduleName, moduleSpec, multiply, nativeFunctions, negate, neverType, notEqual, or, orderType, power, subtract)
+module Morphir.IR.SDK.Basics exposing (add, and, append, boolType, composeLeft, composeRight, divide, encodeOrder, equal, floatType, greaterThan, greaterThanOrEqual, intType, integerDivide, isNumber, lessThan, lessThanOrEqual, moduleName, moduleSpec, multiply, nativeFunctions, negate, neverType, notEqual, or, orderType, power, subtract)
 
 import Dict exposing (Dict)
 import Morphir.IR.Documented exposing (Documented)
@@ -377,6 +377,11 @@ negate refAttributes valueAttributes arg =
 add : a -> Value ta a
 add a =
     Value.Reference a (toFQName moduleName "add")
+
+
+append : a -> Value ta a
+append a =
+    Value.Reference a (toFQName moduleName "append")
 
 
 subtract : a -> Value ta a

--- a/src/Morphir/IR/SDK/Regex.elm
+++ b/src/Morphir/IR/SDK/Regex.elm
@@ -18,12 +18,17 @@
 module Morphir.IR.SDK.Regex exposing (..)
 
 import Dict
+import Morphir.IR.Documented exposing (Documented)
 import Morphir.IR.Module as Module exposing (ModuleName)
 import Morphir.IR.Name as Name
 import Morphir.IR.Path as Path exposing (Path)
+import Morphir.IR.SDK.Basics exposing (boolType, intType)
+import Morphir.IR.SDK.Common exposing (tFun, toFQName, vSpec)
+import Morphir.IR.SDK.List exposing (listType)
+import Morphir.IR.SDK.Maybe exposing (maybeType)
+import Morphir.IR.SDK.String exposing (stringType)
 import Morphir.IR.Type as Type exposing (Specification(..), Type(..))
 import Morphir.IR.Value as Value
-import Morphir.IR.Documented exposing (Documented)
 
 
 moduleName : ModuleName
@@ -34,8 +39,28 @@ moduleName =
 moduleSpec : Module.Specification ()
 moduleSpec =
     { types =
-         Dict.fromList
+        Dict.fromList
             [ ( Name.fromString "Regex", OpaqueTypeSpecification [] |> Documented "Type that represents regular expressions" )
+            , ( Name.fromString "Options"
+              , TypeAliasSpecification []
+                    (Type.Record ()
+                        [ Type.Field [ "case", "insensitive" ] (boolType ())
+                        , Type.Field [ "multiline" ] (boolType ())
+                        ]
+                    )
+                    |> Documented "Type that represents Regex options"
+              )
+            , ( Name.fromString "Match"
+              , TypeAliasSpecification []
+                    (Type.Record ()
+                        [ Type.Field [ "match" ] (stringType ())
+                        , Type.Field [ "index" ] (intType ())
+                        , Type.Field [ "number" ] (intType ())
+                        , Type.Field [ "submatches" ] (listType () (maybeType () (stringType ())))
+                        ]
+                    )
+                    |> Documented "Type that represents a match"
+              )
             ]
     , values =
         let
@@ -58,11 +83,74 @@ moduleSpec =
                 , "replaceAtMost"
                 ]
         in
-        valueNames
-            |> List.map
-                (\valueName ->
-                    ( Name.fromString valueName, Documented "" dummyValueSpec )
-                )
-            |> Dict.fromList
+        Dict.fromList
+            [ vSpec "fromString"
+                [ ( "string", stringType () )
+                ]
+                (maybeType () (regexType ()))
+            , vSpec "fromStringWith"
+                [ ( "options", optionsType () )
+                , ( "string", stringType () )
+                ]
+                (maybeType () (regexType ()))
+            , vSpec "never"
+                []
+                (regexType ())
+            , vSpec "contains"
+                [ ( "regex", regexType () )
+                , ( "string", stringType () )
+                ]
+                (boolType ())
+            , vSpec "split"
+                [ ( "regex", regexType () )
+                , ( "string", stringType () )
+                ]
+                (listType () (stringType ()))
+            , vSpec "find"
+                [ ( "regex", regexType () )
+                , ( "string", stringType () )
+                ]
+                (listType () (matchType ()))
+            , vSpec "replace"
+                [ ( "regex", regexType () )
+                , ( "with", tFun [ matchType () ] (stringType ()) )
+                , ( "string", stringType () )
+                ]
+                (stringType ())
+            , vSpec "splitAtMost"
+                [ ( "number", intType () )
+                , ( "regex", regexType () )
+                , ( "string", stringType () )
+                ]
+                (listType () (stringType ()))
+            , vSpec "findAtMost"
+                [ ( "number", intType () )
+                , ( "regex", regexType () )
+                , ( "string", stringType () )
+                ]
+                (listType () (matchType ()))
+            , vSpec "replaceAtMost"
+                [ ( "number", intType () )
+                , ( "regex", regexType () )
+                , ( "with", tFun [ matchType () ] (stringType ()) )
+                , ( "string", stringType () )
+                ]
+                (stringType ())
+            ]
     , doc = Just "Regular Expressions and related functions."
     }
+
+
+regexType : a -> Type a
+regexType attributes =
+    Type.Reference attributes (toFQName moduleName "Regex") []
+
+
+optionsType : a -> Type a
+optionsType attributes =
+    Type.Reference attributes (toFQName moduleName "Options") []
+
+
+matchType : a -> Type a
+matchType attributes =
+    Type.Reference attributes (toFQName moduleName "Match") []

--- a/src/Morphir/IR/SDK/ResultList.elm
+++ b/src/Morphir/IR/SDK/ResultList.elm
@@ -83,6 +83,14 @@ moduleSpec =
                 [ ( "list", resultListType () (tVar "e") (tVar "a") )
                 ]
                 (Type.Tuple () [ listType () (tVar "e"), listType () (tVar "a") ])
+            , vSpec "keepAllErrors"
+                [ ( "list", resultListType () (tVar "e") (tVar "a") )
+                ]
+                (resultType () (listType () (tVar "e")) (listType () (tVar "a")))
+            , vSpec "keepFirstError"
+                [ ( "list", resultListType () (tVar "e") (tVar "a") )
+                ]
+                (resultType () (tVar "e") (listType () (tVar "a")))
             ]
     , doc = Just "Contains the ResultList type, and related functions."
     }

--- a/src/Morphir/IR/SDK/Tuple.elm
+++ b/src/Morphir/IR/SDK/Tuple.elm
@@ -40,7 +40,7 @@ moduleSpec =
     , values =
         Dict.fromList
             [ vSpec "pair"
-                [ ( "a", tVar "b" )
+                [ ( "a", tVar "a" )
                 , ( "b", tVar "b" )
                 ]
                 (Type.Tuple () [ tVar "a", tVar "b" ])

--- a/src/Morphir/Type/Class.elm
+++ b/src/Morphir/Type/Class.elm
@@ -5,6 +5,7 @@ import Morphir.Type.MetaType as MetaType exposing (MetaType(..))
 
 type Class
     = Number
+    | Appendable
 
 
 member : MetaType -> Class -> Bool
@@ -24,6 +25,17 @@ member metaType class =
             numberTypes
                 |> List.member (targetType metaType)
 
+        Appendable ->
+            case targetType metaType of
+                MetaRef _ ( [ [ "morphir" ], [ "s", "d", "k" ] ], [ [ "string" ] ], [ "string" ] ) [] _ ->
+                    True
+
+                MetaRef _ ( [ [ "morphir" ], [ "s", "d", "k" ] ], [ [ "list" ] ], [ "list" ] ) [ _ ] _ ->
+                    True
+
+                _ ->
+                    False
+
 
 numberTypes : List MetaType
 numberTypes =
@@ -35,3 +47,6 @@ toString class =
     case class of
         Number ->
             "number"
+
+        Appendable ->
+            "appendable"

--- a/src/Morphir/Type/Class/Codec.elm
+++ b/src/Morphir/Type/Class/Codec.elm
@@ -9,5 +9,10 @@ encodeClass class =
     case class of
         Number ->
             Encode.list identity
-                [ Encode.string "number"
+                [ Encode.string "Number"
+                ]
+
+        Appendable ->
+            Encode.list identity
+                [ Encode.string "Appendable"
                 ]


### PR DESCRIPTION
- Implemented Regex in the SDK. 
- Fixed bug in Tuple module. 
- Added missing ResultList functions. 
- Added support for ++ operator.




# Terms

> THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE TERMS OF THE CCLA DATED 2017-11-07 WITH FINOS/LINUX FOUNDATION (FORMERLY THE SYMPHONY SOFTWARE FOUNDATION CCLA).
>
> THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
