### PR TITLE
LetRecursion function argument curry in Scala Backend

### DIFF
--- a/src/Morphir/Scala/Feature/Core.elm
+++ b/src/Morphir/Scala/Feature/Core.elm
@@ -655,16 +655,16 @@ mapValue inScopeVars value =
                                         []
 
                                     else
-                                        [ def.inputTypes
+                                         def.inputTypes
                                             |> List.map
                                                 (\( argName, _, argType ) ->
-                                                    { modifiers = []
+                                                    [{ modifiers = []
                                                     , tpe = mapType argType
                                                     , name = argName |> Name.toCamelCase
                                                     , defaultValue = Nothing
-                                                    }
+                                                    }]
                                                 )
-                                        ]
+
                                 , returnType =
                                     Just (mapType def.outputType)
                                 , body =

--- a/tests-integration/reference-model/src/Morphir/Reference/Model/TypeAscription.elm
+++ b/tests-integration/reference-model/src/Morphir/Reference/Model/TypeAscription.elm
@@ -40,3 +40,15 @@ target2 a1 a2 =
 target3 : (String -> Int -> Custom) -> Bool
 target3 ctor =
     True
+
+
+letRecursion items =
+    let
+        addHelper prev lst =
+            case lst of
+                [] ->
+                    prev
+                head :: rest ->
+                    addHelper (prev + head) rest
+    in
+    addHelper 0 items


### PR DESCRIPTION


# Terms

> THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE TERMS OF THE CCLA DATED 2017-11-07 WITH FINOS/LINUX FOUNDATION (FORMERLY THE SYMPHONY SOFTWARE FOUNDATION CCLA).
>
> THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
