### PR TITLE
elm frontend negative literal impl switched from apply to reference

### DIFF
--- a/src/Morphir/Elm/IncrementalFrontend/Mapper.elm
+++ b/src/Morphir/Elm/IncrementalFrontend/Mapper.elm
@@ -311,8 +311,18 @@ mapExpression resolveReferenceName moduleName variables (Node range expr) =
             Ok (Value.Literal defaultValueAttribute (Literal.FloatLiteral value))
 
         Expression.Negation arg ->
-            mapExpression resolveReferenceName moduleName variables arg
-                |> Result.map (SDKBasics.negate defaultValueAttribute defaultValueAttribute)
+            case arg of
+                Node _ exp ->
+                    case exp of
+                        Integer value ->
+                            Ok (Value.Literal defaultValueAttribute (Literal.WholeNumberLiteral -value))
+
+                        Floatable value ->
+                            Ok (Value.Literal defaultValueAttribute (Literal.FloatLiteral -value))
+
+                        _ ->
+                            mapExpression resolveReferenceName moduleName variables arg
+                                |> Result.map (SDKBasics.negate defaultValueAttribute defaultValueAttribute)
 
         Expression.Literal value ->
             Ok (Value.Literal defaultValueAttribute (Literal.StringLiteral value))


### PR DESCRIPTION


# Terms

> THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE TERMS OF THE CCLA DATED 2017-11-07 WITH FINOS/LINUX FOUNDATION (FORMERLY THE SYMPHONY SOFTWARE FOUNDATION CCLA).
>
> THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
