### PR TITLE
Additional functions for LocalDate needed for business rules and morphir-scala

### DIFF
--- a/src/Morphir/SDK/LocalDate.elm
+++ b/src/Morphir/SDK/LocalDate.elm
@@ -19,7 +19,8 @@ module Morphir.SDK.LocalDate exposing
     ( LocalDate
     , diffInDays, diffInWeeks, diffInMonths, diffInYears
     , addDays, addWeeks, addMonths, addYears
-    , toISOString, fromCalendarDate, fromISO, fromOrdinalDate, fromParts, fromRataDie, toRataDie
+    , fromCalendarDate, fromISO, fromOrdinalDate, fromParts, fromRataDie
+    , toISOString, toRataDie
     , DayOfWeek(..), dayOfWeek, isWeekend, isWeekday
     , Month(..)
     , year, month, day
@@ -43,8 +44,11 @@ module Morphir.SDK.LocalDate exposing
 
 @docs fromCalendarDate, fromISO, fromOrdinalDate, fromParts, fromRataDie
 
+
 # Convert
+
 @docs toISOString, toRataDie
+
 
 # Query
 
@@ -52,8 +56,6 @@ module Morphir.SDK.LocalDate exposing
 @docs Month
 @docs year, month, day
 
-
-@docs toISOString
 -}
 
 import Date exposing (Date, Unit(..))
@@ -121,6 +123,7 @@ addYears : Int -> LocalDate -> LocalDate
 addYears count date =
     Date.add Years count date
 
+
 {-| Create a date from a [calendar date][gregorian]: a year, month, and day of
 the month. Out-of-range day values will be clamped.
 
@@ -136,9 +139,11 @@ fromCalendarDate : Int -> Month -> Int -> LocalDate
 fromCalendarDate y m d =
     Date.fromCalendarDate y (monthToMonth m) d
 
+
 fromOrdinalDate : Int -> Int -> LocalDate
 fromOrdinalDate y d =
     Date.fromOrdinalDate y d
+
 
 {-| Construct a LocalDate based on ISO formatted string. Opportunity for error denoted by Maybe return type.
 -}
@@ -235,6 +240,7 @@ month localDate =
         Time.Dec ->
             December
 
+
 monthToMonth : Month -> Time.Month
 monthToMonth m =
     case m of
@@ -273,6 +279,7 @@ monthToMonth m =
 
         December ->
             Time.Dec
+
 
 {-| The day of the month (1–31).
 -}
@@ -358,6 +365,7 @@ type Month
     | November
     | December
 
+
 {-| Construct a LocalDate from Integer Rata Die, a system for system for assigning calendar days to
 numbers, with 1 representing 0001-01-01.
 -}
@@ -366,7 +374,7 @@ fromRataDie rataDieNumber =
     Date.fromRataDie rataDieNumber
 
 
-{-| Convert a LocalDate to its number representation in Rata Die.  Rata Die is a system for
+{-| Convert a LocalDate to its number representation in Rata Die. Rata Die is a system for
 assigning calendar days to numbers, with 1 representing 0001-01-01.
 -}
 toRataDie : LocalDate -> Int

--- a/src/Morphir/SDK/LocalDate.elm
+++ b/src/Morphir/SDK/LocalDate.elm
@@ -19,7 +19,7 @@ module Morphir.SDK.LocalDate exposing
     ( LocalDate
     , diffInDays, diffInWeeks, diffInMonths, diffInYears
     , addDays, addWeeks, addMonths, addYears
-    , toISOString, fromISO, fromParts
+    , toISOString, fromCalendarDate, fromISO, fromOrdinalDate, fromParts, fromRataDie, toRataDie
     , DayOfWeek(..), dayOfWeek, isWeekend, isWeekday
     , Month(..)
     , year, month, day
@@ -41,8 +41,10 @@ module Morphir.SDK.LocalDate exposing
 
 # Constructors
 
-@docs toISOString, fromISO, fromParts
+@docs fromCalendarDate, fromISO, fromOrdinalDate, fromParts, fromRataDie
 
+# Convert
+@docs toISOString, toRataDie
 
 # Query
 
@@ -50,6 +52,8 @@ module Morphir.SDK.LocalDate exposing
 @docs Month
 @docs year, month, day
 
+
+@docs toISOString
 -}
 
 import Date exposing (Date, Unit(..))
@@ -117,6 +121,24 @@ addYears : Int -> LocalDate -> LocalDate
 addYears count date =
     Date.add Years count date
 
+{-| Create a date from a [calendar date][gregorian]: a year, month, and day of
+the month. Out-of-range day values will be clamped.
+
+    import Date exposing (fromCalendarDate)
+    import Time exposing (Month(..))
+
+    fromCalendarDate 2018 Sep 26
+
+[gregorian]: https://en.wikipedia.org/wiki/Proleptic_Gregorian_calendar
+
+-}
+fromCalendarDate : Int -> Month -> Int -> LocalDate
+fromCalendarDate y m d =
+    Date.fromCalendarDate y (monthToMonth m) d
+
+fromOrdinalDate : Int -> Int -> LocalDate
+fromOrdinalDate y d =
+    Date.fromOrdinalDate y d
 
 {-| Construct a LocalDate based on ISO formatted string. Opportunity for error denoted by Maybe return type.
 -}
@@ -213,6 +235,44 @@ month localDate =
         Time.Dec ->
             December
 
+monthToMonth : Month -> Time.Month
+monthToMonth m =
+    case m of
+        January ->
+            Time.Jan
+
+        February ->
+            Time.Feb
+
+        March ->
+            Time.Mar
+
+        April ->
+            Time.Apr
+
+        May ->
+            Time.May
+
+        June ->
+            Time.Jun
+
+        July ->
+            Time.Jul
+
+        August ->
+            Time.Aug
+
+        September ->
+            Time.Sep
+
+        October ->
+            Time.Oct
+
+        November ->
+            Time.Nov
+
+        December ->
+            Time.Dec
 
 {-| The day of the month (1–31).
 -}
@@ -297,3 +357,18 @@ type Month
     | October
     | November
     | December
+
+{-| Construct a LocalDate from Integer Rata Die, a system for system for assigning calendar days to
+numbers, with 1 representing 0001-01-01.
+-}
+fromRataDie : Int -> LocalDate
+fromRataDie rataDieNumber =
+    Date.fromRataDie rataDieNumber
+
+
+{-| Convert a LocalDate to its number representation in Rata Die.  Rata Die is a system for
+assigning calendar days to numbers, with 1 representing 0001-01-01.
+-}
+toRataDie : LocalDate -> Int
+toRataDie localDate =
+    Date.toRataDie localDate

--- a/src/Morphir/SDK/LocalDate.elm
+++ b/src/Morphir/SDK/LocalDate.elm
@@ -127,10 +127,9 @@ addYears count date =
 {-| Create a date from a [calendar date][gregorian]: a year, month, and day of
 the month. Out-of-range day values will be clamped.
 
-    import Date exposing (fromCalendarDate)
-    import Time exposing (Month(..))
+    import Morphir.SDK.LocalDate exposing (fromCalendarDate, Month(..))
 
-    fromCalendarDate 2018 Sep 26
+    fromCalendarDate 2018 September 26
 
 [gregorian]: https://en.wikipedia.org/wiki/Proleptic_Gregorian_calendar
 
@@ -140,6 +139,16 @@ fromCalendarDate y m d =
     Date.fromCalendarDate y (monthToMonth m) d
 
 
+{-| Create a date from an [ordinal date][ordinaldate]: a year and day of the
+year. Out-of-range day values will be clamped.
+
+    import Morphir.SDK.LocalDate exposing (fromOrdinalDate)
+
+    fromOrdinalDate 2018 269
+
+[ordinaldate]: https://en.wikipedia.org/wiki/Ordinal_date
+
+-}
 fromOrdinalDate : Int -> Int -> LocalDate
 fromOrdinalDate y d =
     Date.fromOrdinalDate y d

--- a/tests/Morphir/SDK/LocalDateTests.elm
+++ b/tests/Morphir/SDK/LocalDateTests.elm
@@ -104,6 +104,10 @@ constructorTests =
             \_ ->
                 LocalDate.fromCalendarDate 2023 December 39
                     |> Expect.equal (Date.fromCalendarDate 2023 Dec 31)
+        , test "valid fromOrdinalDate" <|
+            \_ ->
+                LocalDate.fromOrdinalDate 2023 15
+                    |> Expect.equal (Date.fromCalendarDate 2023 Jan 15)
         , test "valid fromRataDie" <|
             \_ ->
                 LocalDate.fromRataDie 1

--- a/tests/Morphir/SDK/LocalDateTests.elm
+++ b/tests/Morphir/SDK/LocalDateTests.elm
@@ -96,4 +96,29 @@ constructorTests =
             \_ ->
                 LocalDate.fromParts 2020 2 30
                     |> Expect.equal Nothing
+        , test "valid fromCalendarDate" <|
+            \_ ->
+                LocalDate.fromCalendarDate 2023 December 25
+                    |> Expect.equal (Date.fromCalendarDate 2023 Dec 25)
+        , test "invalid but pinned fromCalendarDate" <|
+            \_ ->
+                LocalDate.fromCalendarDate 2023 December 39
+                    |> Expect.equal (Date.fromCalendarDate 2023 Dec 31)
+        , test "valid fromRataDie" <|
+            \_ ->
+                LocalDate.fromRataDie 1
+                    |> Expect.equal (Date.fromCalendarDate 1 Jan 1)
+        , test "valid contemporary fromRataDie" <|
+            \_ ->
+                LocalDate.fromRataDie 738860
+                    |> Expect.equal (Date.fromCalendarDate 2023 Dec 6)
+        , test "valid toRataDie" <|
+            \_ ->
+                Date.fromCalendarDate 1 Jan 1
+                    |> LocalDate.toRataDie
+                    |> Expect.equal 1
+        , test "valid contemporary toRataDie" <|
+            \_ ->
+                LocalDate.toRataDie (Date.fromCalendarDate 2023 Dec 6)
+                    |> Expect.equal 738860
         ]


### PR DESCRIPTION
Additional functions for LocalDate needed for business rules and morphir-scala

In particular there is a need to provide infallible constructors for `LocalDate`, so the following were added:

## Constructors

- `fromRataDie`
- `fromCalendarDate`
- `fromOrdinalDate`

> NOTE: `fromCalendarDate` uses an internal function `monthToMonth` that function is intentionally left internal.

In order to support converting to and from a Rata Die based date we included some conversions as well:

## Convert

- `toRataDie`


# Terms

> THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE TERMS OF THE CCLA DATED 2017-11-07 WITH FINOS/LINUX FOUNDATION (FORMERLY THE SYMPHONY SOFTWARE FOUNDATION CCLA).
>
> THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
