### PR TITLE
Fix release

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -13,16 +13,16 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
         os: [ ubuntu-latest ]
     steps:
-      - uses: actions/checkout@v2
-      
+      - uses: actions/checkout@v4
+
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-      
+
       - name: Cache NPM
         uses: actions/cache@v3
         with:
@@ -30,34 +30,34 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
-      
+
       - name: Cache Elm
         uses: actions/cache@v3
         with:
           path: ~/.elm
           key: ${{ runner.os }}-elm-${{ hashFiles('**/elm.json') }}
           restore-keys: |
-            ${{ runner.os }}-elm- 
-      
+            ${{ runner.os }}-elm-
+
       - name: Download dependencies
         run: npm ci
-      
+
       - name: Build
         run: npm run build --if-present
-      
+
       - name: Running Test
         run: npm test
 
-  # CVE scanning 
+  # CVE scanning
   cvescan:
     name: CVE Scanning
     runs-on: ubuntu-latest
     needs: [ build ]
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [18.x]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
@@ -76,7 +76,7 @@ jobs:
     # Skip any PR created by dependabot to avoid permission issues
     if: (github.actor != 'dependabot[bot]')
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: semgrep scan --config auto --severity ERROR
         env:
           SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ redistributable/Scala
 cli/web/insightapp.js
 cli/treeStuff.js
 cli/index.html
+cli2/lib/
 lib/geneated
 cadl-Frontend/cadl-output
 Morphir.Elm.CLI.js

--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/hydrogen

--- a/cli2/.gitignore
+++ b/cli2/.gitignore
@@ -2,4 +2,3 @@ node_modules
 morphir-elm.ts
 package-lock.json
 package.json
-lib

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -99,6 +99,7 @@ const buildMorphirAPI2 = async ()=>{
         .pipe(dest('./lib/generated/morphir/sdk'))
        return await execa('npx tsc', ['--project',path.join('.','lib','tsconfig.json')])
     } catch (error) {
+        console.error("Error building morphir API 2", error);
         return error
     }
 
@@ -168,6 +169,7 @@ async function morphirJsonSchemaGen(inputPath, outputDir, target) {
     try {
         await execa('node', args, {stdio})
     } catch (err) {
+        console.log("Error running json-schema-gen command", err);
         throw(err)
     }
 }
@@ -295,7 +297,7 @@ async function testIntegrationBuildSpark(cb) {
         )
     } catch (err) {
         if (err.code == 'ENOENT') {
-            console.log("Skipping testIntegrationBuildSpark as `mill` build tool isn't available.");
+            console.error("Skipping testIntegrationBuildSpark as `mill` build tool isn't available.");
         } else {
             throw err;
         }
@@ -310,7 +312,7 @@ async function testIntegrationTestSpark(cb) {
         )
     } catch (err) {
         if (err.code == 'ENOENT') {
-            console.log("Skipping testIntegrationTestSpark as `mill` build tool isn't available.");
+            console.error("Skipping testIntegrationTestSpark as `mill` build tool isn't available.");
         } else {
             throw err;
         }
@@ -339,7 +341,7 @@ async function testCreateCSV(cb) {
     } else {
         code_no = shell.exec('bash ./create_csv_files.sh', { cwd: './tests-integration/spark/elm-tests/tests' }).code
         if (code_no != 0) {
-            console.log('ERROR: CSV files cannot be created')
+            console.error('ERROR: CSV files cannot be created')
             return false;
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "morphir-elm",
       "version": "2.87.3",
-      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "ajv": "^8.10.0",


### PR DESCRIPTION
…affects npm pack

NPM uses the `npm-packlist` package to create the package to create or publish a npm package. As of version `6.0.0` of `npm-packlist` root level ignore patterns in `.gitignore` are ignored when you use `files` in `package.json` (however nested are not ignored). 

Issues were arising when publishing because `cli2/.gitignore` contained the `lib` folder which is actually needed in the deploy. Because we want to ignore `cli2/lib` from git because it is generated, but we **DO** want to include the folder in the package, we need to add `cli2/lib/` to the root `.gitignore` file.

Also since it is not clear what version of Node folks are using, I've also added an `.nvmrc` file which is currently set to `lts/hydrogen` (version 18.x) which is  an LTS version in Maintenance mode through June 2026.

Finally, updated the GitHub actions to also use 18.x



# Terms

> THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE TERMS OF THE CCLA DATED 2017-11-07 WITH FINOS/LINUX FOUNDATION (FORMERLY THE SYMPHONY SOFTWARE FOUNDATION CCLA).
>
> THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
