### PR TITLE
Improve how the Morphir CLI handles dependencies and add "includes" to allow providing dependencies at the command line

### DIFF
--- a/cli2/cli.ts
+++ b/cli2/cli.ts
@@ -5,6 +5,7 @@ import * as util from "util";
 import * as path from "path";
 import * as FileChanges from "./FileChanges";
 import * as Dependencies from "./dependencies";
+import {DependencyConfig} from "./dependencies";
 import {z} from "zod";
 
 const fsExists = util.promisify(fs.exists);
@@ -42,13 +43,14 @@ async function make(
   );
 
   const includes = Includes.parse(options.include);
-
-  //load List Of Dependency IR
-  const dependencies = await Dependencies.loadDependencies({
+  const dependencyConfig = DependencyConfig.parse({
     dependencies: morphirJson.dependencies,
     localDependencies: morphirJson.localDependencies,
     includes: includes
-  });
+  })
+
+  //load List Of Dependency IR
+  const dependencies = await Dependencies.loadDependencies(dependencyConfig);
 
   // check the status of the build incremental flag
   if (options.buildIncrementally == false) {

--- a/cli2/cli.ts
+++ b/cli2/cli.ts
@@ -17,6 +17,7 @@ const worker = require("./../Morphir.Elm.CLI").Elm.Morphir.Elm.CLI.init();
 interface MorphirJson {
   name: string;
   sourceDirectory: string;
+  dependencies?: string[];
   localDependencies?: string[];
   exposedModules: string[];
 }
@@ -36,9 +37,9 @@ async function make(
   );
 
   //load List Of Dependency IR
-  const dependencies = await Dependencies.getDependecies(
-    morphirJson.localDependencies ?? []
-  );
+  const dependencies = await Dependencies.getDependencies({
+    localDependencies: morphirJson.localDependencies
+  });
 
   // check the status of the build incremental flag
   if (options.buildIncrementally == false) {

--- a/cli2/cli.ts
+++ b/cli2/cli.ts
@@ -5,8 +5,8 @@ import * as util from "util";
 import * as path from "path";
 import * as FileChanges from "./FileChanges";
 import * as Dependencies from "./dependencies";
-import {DependencyConfig} from "./dependencies";
-import {z} from "zod";
+import { DependencyConfig } from "./dependencies";
+import { z } from "zod";
 
 const fsExists = util.promisify(fs.exists);
 const fsWriteFile = util.promisify(fs.writeFile);
@@ -50,7 +50,7 @@ async function make(
   })
 
   //load List Of Dependency IR
-  const dependencies = await Dependencies.loadDependencies(dependencyConfig);
+  const dependencies = await Dependencies.loadAllDependencies(dependencyConfig);
 
   // check the status of the build incremental flag
   if (options.buildIncrementally == false) {

--- a/cli2/dependencies.ts
+++ b/cli2/dependencies.ts
@@ -1,17 +1,103 @@
 import * as util from "util";
 import * as fs from "fs";
+import {z} from "zod";
+
+const UnclassifiedDependency = z.object({
+  kind: z.literal("unclassified"),
+  path: z.string(),
+});
+
+const LocalDependency = z.object({
+  kind: z.literal("local"),
+  path: z.string()
+});
+
+const HttpDependency = z.object({
+  kind: z.literal("http"),
+  url: z.string().url()
+});
+
+const GithubData = z.object({
+  owner: z.string(),
+  repo: z.string(),
+  baseUrl: z.string().optional()
+});
+
+const GithubConfig = z.union([GithubData, z.string()]);
+
+const GithubDependency = z.object({
+  kind: z.literal("github"),
+  config: GithubConfig,
+});
+
+const RemoteDependency = z.discriminatedUnion("kind",[
+    HttpDependency,
+    GithubDependency
+]);
+
+const DependencyInfo = z.discriminatedUnion("kind",[
+    LocalDependency,
+    HttpDependency
+]);
+
+const DependencyConfig = z.object({
+  dependencies: z.array(z.string()).optional(),
+  localDependencies: z.array(z.string()).optional(),
+  includes: z.array(z.string()).optional(),
+});
+
+const MorphirDistribution = z.tuple([z.string()]).rest(z.unknown());
+const MorphirIRFile = z.object ({
+  formatVersion: z.number().int(),
+  distribution: MorphirDistribution
+}).passthrough();
+
+type LocalDependency = z.infer<typeof LocalDependency>;
+type UnclassifiedDependency = z.infer<typeof UnclassifiedDependency>;
+type HttpDependency = z.infer<typeof HttpDependency>;
+type GithubDependency = z.infer<typeof GithubDependency>;
+type RemoteDependency = z.infer<typeof RemoteDependency>;
+type GithubData = z.infer<typeof GithubData>;
+type GithubConfig = z.infer<typeof GithubConfig>;
+type DependencyInfo = z.infer<typeof DependencyInfo>;
+type MorphirDistribution = z.infer<typeof MorphirDistribution>;
+type MorphirIRFile = z.infer<typeof MorphirIRFile>;
+export type DependencyConfig = z.infer<typeof DependencyConfig>;
+
 const fsReadFile = util.promisify(fs.readFile);
 
-export async function getDependecies(
-  localDependencies: string[]
-): Promise<any[]> {
-  const loadedDependencies = localDependencies.map(async (dependencyPath) => {
+export async function getDependencies(dependencyInfo:DependencyConfig): Promise<any[]> {
+  const workItems = [];
+  if(dependencyInfo.localDependencies !== undefined) {
+    let work = loadLocalDependencies(dependencyInfo.localDependencies);
+    workItems.push(work);
+  }
+  return Promise.all(workItems);
+}
+
+
+
+async function loadLocalDependencies(dependencies:string[]): Promise<any[]> {
+
+  const workItems = dependencies.map(async (dependencyPath) => {
     if (fs.existsSync(dependencyPath)) {
       const dependencyIR = (await fsReadFile(dependencyPath)).toString();
-      return JSON.parse(dependencyIR);
+      const ir = JSON.parse(dependencyIR);
+      return ir;
     } else {
       throw new Error(`${dependencyPath} does not exist`);
     }
   });
-  return Promise.all(loadedDependencies);
+  return Promise.all(workItems);
 }
+
+export async function loadDependencies():Promise<any[]>{
+  return [];
+}
+
+function toLocalDependency(dependency:string) : LocalDependency {
+  return { kind:"local", path:dependency};
+}
+
+
+

--- a/cli2/dependencies.ts
+++ b/cli2/dependencies.ts
@@ -36,36 +36,6 @@ const Url = z.string().url().transform((url) => new URL(url));
 
 const PathOrUrl = z.union([FileUrl, z.string().trim().min(1)]);
 
-const DependencyBase = z.object({
-  source: z.enum(["dependencies", "localDependencies", "includes"]).optional()
-});
-
-const UnclassifiedDependency = DependencyBase.extend({
-  kind: z.literal("unclassified"),
-  path: z.string()
-});
-
-
-const FileDependency = DependencyBase.extend({
-  kind: z.literal("file"),
-  pathOrUrl: PathOrUrl,
-});
-
-const DataUrlDependency = DependencyBase.extend({
-  kind: z.literal("dataUrl"),
-  url: DataUrl
-})
-
-const LocalDependency = z.discriminatedUnion("kind", [
-  FileDependency,
-  DataUrlDependency
-]);
-
-const HttpDependency = DependencyBase.extend({
-  kind: z.literal("http"),
-  url: Url
-});
-
 const GithubData = z.object({
   owner: z.string(),
   repo: z.string(),
@@ -73,32 +43,6 @@ const GithubData = z.object({
 });
 
 const GithubConfig = z.union([GithubData, z.string()]);
-
-const GithubDependency = DependencyBase.extend({
-  kind: z.literal("github"),
-  config: GithubConfig,
-});
-
-const RemoteDependency = z.discriminatedUnion("kind", [
-  HttpDependency,
-  GithubDependency
-]);
-
-const DependencyInfo = z.discriminatedUnion("kind", [
-  FileDependency,
-  DataUrlDependency,
-  HttpDependency,
-  GithubDependency,
-  UnclassifiedDependency
-]);
-
-const ClassifiedDependency = z.discriminatedUnion("kind", [
-  FileDependency,
-  DataUrlDependency,
-  HttpDependency,
-  GithubDependency
-]);
-
 
 const DependencySettings = z.union([DataUrl, FileUrl, z.string().trim()])
 const Dependencies = z.array(DependencySettings).default([]);
@@ -154,185 +98,68 @@ type DataUrl = z.infer<typeof DataUrl>;
 type FileUrl = z.infer<typeof FileUrl>;
 type Url = z.infer<typeof Url>;
 type DependencyConfigToDependencyEvents = z.infer<typeof DependencyConfigToDependencyEvents>
-type LocalDependency = z.infer<typeof LocalDependency>;
-type PathDependency = z.infer<typeof FileDependency>;
 type PathOrUrl = z.infer<typeof PathOrUrl>;
-type DataUrlDependency = z.infer<typeof DataUrlDependency>;
-type UnclassifiedDependency = z.infer<typeof UnclassifiedDependency>;
-type ClassifiedDependency = z.infer<typeof ClassifiedDependency>;
-type HttpDependency = z.infer<typeof HttpDependency>;
-type GithubDependency = z.infer<typeof GithubDependency>;
-type RemoteDependency = z.infer<typeof RemoteDependency>;
 type GithubData = z.infer<typeof GithubData>;
 type GithubConfig = z.infer<typeof GithubConfig>;
-type DependencyInfo = z.infer<typeof DependencyInfo>;
 type DependencyEvent = z.infer<typeof DependencyEvent>;
 type MorphirDistribution = z.infer<typeof MorphirDistribution>;
 type MorphirIRFile = z.infer<typeof MorphirIRFile>;
 export type DependencyConfig = z.infer<typeof DependencyConfig>;
 
-function toLocalDependency(dependency: string): LocalDependency {
-  const dataUrl = parseDataUrl(dependency);
-  if (dataUrl == null) {
-    return { kind: "file", pathOrUrl: PathOrUrl.parse(dependency) };
-  } else {
-    return { kind: "dataUrl", url: dataUrl };
-  }
-}
-
 export async function loadAllDependencies(config: DependencyConfig) {
   const events = DependencyConfigToDependencyEvents.parse(config);
-  const results = events.map(eventToDependencyInfo);
+  const results = events.map(load);
   const finalResults = await Promise.all(results);
   return finalResults.flatMap((result) => {
     if (result.isOk()) {
-      return result.value;
+      console.error("Successfully loaded dependency", result.value.dependency)
+      return result.value.dependency;
     } else {
+      console.error("Error loading dependency", result.error);
       return [];
     }
   });
 }
 
-async function eventToDependencyInfo(event: DependencyEvent) {
+function load(event: DependencyEvent) {
+  console.error("Loading event", event);
   let source: "dependencies" | "localDependencies" | "includes";
   let payload = event.payload;
   switch (event.eventKind) {
     case 'IncludeProvided':
       source = "includes";
-      return await loadDependenciesFromString(event.payload);
+      return loadDependenciesFromString(event.payload, source)
+        .map((dependency) => ({ dependency: dependency, source: source, payload: payload }));
     case 'LocalDependencyProvided':
       source = "localDependencies";
-      return await loadDependenciesFromString(event.payload);
+      return loadDependenciesFromString(event.payload, source)
+        .map((dependency) => ({ dependency: dependency, source: source, payload: payload }));
     case 'DependencyProvided':
       source = "dependencies";
       if (typeof payload === "string") {
-        return await loadDependenciesFromString(payload);
+        return loadDependenciesFromString(payload, source)
+          .map((dependency) => ({ dependency: dependency, source: source, payload: payload }));
       } else {
-        return await loadDependenciesFromURL(payload);
+        return loadDependenciesFromURL(payload, source)
+          .map((dependency) => ({ dependency: dependency, source: source, payload: payload }));
       }
   }
 }
 
-export async function loadDependencies(dependencyConfig: DependencyConfig) {
-  let remoteDependencies: RemoteDependency[] = [];
-  let localDependencies: LocalDependency[] = (dependencyConfig.localDependencies ?? []).map(toLocalDependency).map((d) => {
-    d.source = "localDependencies";
-    return d;
-  });
-  if (dependencyConfig.includes) {
-    const includes = dependencyConfig.includes.map(toLocalDependency).map((d) => {
-      d.source = "includes";
-      return d;
-    });
-    localDependencies.push(...includes);
-  }
-  if (dependencyConfig.dependencies) {
-    dependencyConfig.dependencies.forEach((input) => {
-      let parseResult = DataUrl.safeParse(input);
-      let parseSuccess = parseResult.success;
-      if (parseSuccess) {
-        localDependencies.push({ kind: "dataUrl", url: parseResult.data, source: "dependencies" });
-      }
-      if (!parseSuccess) {
-        let parseResult = FileUrl.safeParse(input);
-        parseSuccess = parseResult.success;
-        if (parseResult.success) {
-          localDependencies.push({ kind: "file", pathOrUrl: parseResult.data, source: "dependencies" });
-        }
-      }
-      if (!parseSuccess) {
-        let parseResult = HttpDependency.safeParse({ kind: "http", url: input, source: "dependencies" });
-        parseSuccess = parseResult.success;
-        if (parseResult.success) {
-          let httpDependency: HttpDependency = parseResult.data;
-          remoteDependencies.push(httpDependency);
-        }
-      }
-
-    })
-  }
-  const localWorkItems = loadLocalDependencies(localDependencies);
-  const remoteWorkItems = loadRemoteDependencies(remoteDependencies);
-  const allResults = await Promise.all([localWorkItems, remoteWorkItems]);
-  return allResults.flat();
-}
-
-async function loadLocalDependencies(dependencies: LocalDependency[]): Promise<any[]> {
-  const promises = dependencies.map(async dependency => {
-    switch (dependency.kind) {
-      case 'file':
-        if (typeof dependency.pathOrUrl === "string") {
-          if (fs.existsSync(dependency.pathOrUrl)) {
-            const irJsonStr = (await fsReadFile(dependency.pathOrUrl)).toString();
-            return JSON.parse(irJsonStr);
-          } else {
-            throw new LocalDependencyNotFound(`Local dependency at path "${dependency.pathOrUrl}" does not exist`, dependency.pathOrUrl);
-          }
-        } else {
-          try {
-            const stream = await getUri(dependency.pathOrUrl);
-            const jsonBuffer = await toBuffer(stream);
-            return JSON.parse(jsonBuffer.toString());
-          } catch (err: any) {
-            if (err.code === 'ENOTFOUND') {
-              throw new LocalDependencyNotFound(`Local dependency at url "${dependency.pathOrUrl}" does not exist`, dependency.pathOrUrl, err);
-            } else {
-              throw err;
-            }
-          }
-        }
-        break;
-      case 'dataUrl':
-        const encodingName = labelToName(dependency.url.mimeType.parameters.get("charset") || "utf-8") || "UTF-8";
-        const bodyDecoded = decode(dependency.url.body, encodingName);
-        return JSON.parse(bodyDecoded);
-    }
-  })
-  return Promise.all(promises);
-}
-
-async function loadRemoteDependencies(dependencies: RemoteDependency[]): Promise<any[]> {
-  const promises = dependencies.map(async dependency => {
-    switch (dependency.kind) {
-      case 'http':
-        if (dependency.url.protocol.startsWith("http")) {
-          const stream = await getUri(dependency.url.toString());
-          const buffer = await toBuffer(stream);
-          const jsonString = buffer.toString();
-          return JSON.parse(jsonString);
-        }
-        break;
-    }
-  });
-  return Promise.all(promises);
-}
-
-function isRemoteDependency(dependency: DependencyInfo): undefined | boolean {
-  switch (dependency.kind) {
-    case 'dataUrl':
-    case 'file':
-      return false;
-    case 'http':
-      return true;
-    case 'github':
-      return true;
-    default:
-      return undefined;
-  }
-}
-
-function loadDependenciesFromString(input: string) {
+function loadDependenciesFromString(input: string, source: string) {
   const doWork = async () => {
     let sanitized = input.trim();
     let { success, data } = DataUrl.safeParse(sanitized);
     if (success) {
-      const dataFromDataUrl = await getUri(data);
-      const buffer = await toBuffer(dataFromDataUrl);
-      const jsonString = buffer.toString();
-      return JSON.parse(jsonString);
+      console.error("Loading Data url", data);
+      const encodingName = labelToName(data.mimeType.parameters.get("charset") || "utf-8") || "UTF-8";
+      const bodyDecoded = decode(data.body, encodingName);
+      console.error("Data from data url", bodyDecoded);
+      return JSON.parse(bodyDecoded);
     }
     let { success: fileSuccess, data: fileData } = FileUrl.safeParse(sanitized);
     if (fileSuccess && fileData !== undefined) {
+      console.error("Loading file url", fileData);
       const data = await getUri(fileData);
       const buffer = await toBuffer(data);
       const jsonString = buffer.toString();
@@ -340,7 +167,9 @@ function loadDependenciesFromString(input: string) {
     }
     let { success: urlSuccess, data: urlData } = Url.safeParse(sanitized);
     if (urlSuccess && urlData !== undefined) {
+      console.error("Loading url", urlData);
       if (urlData.protocol.startsWith("http") || urlData.protocol.startsWith("ftp")) {
+        console.error("Loading http or ftp url", urlData);
         const data = await getUri(urlData);
         const buffer = await toBuffer(data);
         const jsonString = buffer.toString();
@@ -349,17 +178,17 @@ function loadDependenciesFromString(input: string) {
     }
     throw new DependencyError("Invalid dependency string", input);
   }
-  return ResultAsync.fromPromise(doWork(), (err) => new DependencyError("Error loading dependency", input, err));
+  return ResultAsync.fromPromise(doWork(), (err) => new DependencyError("Error loading dependency", source, input, err));
 }
 
-function loadDependenciesFromURL(url: URL | Url) {
+function loadDependenciesFromURL(url: URL | Url, source: string) {
   const doWork = async () => {
     const data = await getUri(url);
     const buffer = await toBuffer(data);
     const jsonString = buffer.toString();
     return JSON.parse(jsonString);
   }
-  return ResultAsync.fromPromise(doWork(), (err) => new DependencyError("Error loading dependency", url, err));
+  return ResultAsync.fromPromise(doWork(), (err) => new DependencyError("Error loading dependency", source, url, err));
 }
 
 async function toBuffer(stream: Readable): Promise<Buffer> {
@@ -371,19 +200,26 @@ async function toBuffer(stream: Readable): Promise<Buffer> {
 }
 
 class DependencyError extends Error {
-  constructor(message: string, dependency?: string | FileUrl | DataUrl | URL, cause?: Error | unknown) {
+  constructor(message: string, source?: string, dependency?: string | FileUrl | DataUrl | URL, cause?: Error | unknown) {
     super(message);
     this.name = "DependencyError";
     if (cause) {
       this.cause = cause;
     }
+    if (dependency) {
+      this.dependency = dependency;
+    }
+    if (source) {
+      this.source = source;
+    }
   }
   cause?: Error | unknown;
   dependency?: string | FileUrl | DataUrl | URL;
+  source?: string;
 }
 
 class LocalDependencyNotFound extends Error {
-  constructor(message: string, pathOrUrl?: PathOrUrl, cause?: Error | unknown) {
+  constructor(message: string, source?: string, pathOrUrl?: PathOrUrl, cause?: Error | unknown) {
     super(message);
     this.name = "LocalDependencyNotFound";
     if (cause) {
@@ -392,9 +228,13 @@ class LocalDependencyNotFound extends Error {
     if (pathOrUrl) {
       this.pathOrUrl = pathOrUrl;
     }
+    if (source) {
+      this.source = source;
+    }
   }
 
   cause?: Error | unknown;
   pathOrUrl?: PathOrUrl;
+  source?: string;
 
 }

--- a/cli2/morphir-make.ts
+++ b/cli2/morphir-make.ts
@@ -16,6 +16,7 @@ program
     .option('-o, --output <path>', 'Target file location where the Morphir IR will be saved.', 'morphir-ir.json')
     .option('-t, --types-only', 'Only include type information in the IR, no values.', false)
     .option('-i, --indent-json', 'Use indentation in the generated JSON file.', false)
+    .option("-I, --include <path>", "Include additional Morphir distributions as a dependency. Can be specified multiple times.")
     .parse(process.argv)
 
 const dirAndOutput = program.opts()

--- a/cli2/morphir-make.ts
+++ b/cli2/morphir-make.ts
@@ -16,7 +16,7 @@ program
     .option('-o, --output <path>', 'Target file location where the Morphir IR will be saved.', 'morphir-ir.json')
     .option('-t, --types-only', 'Only include type information in the IR, no values.', false)
     .option('-i, --indent-json', 'Use indentation in the generated JSON file.', false)
-    .option("-I, --include <path>", "Include additional Morphir distributions as a dependency. Can be specified multiple times.")
+    .option("-I, --include [pathOrUrl...]", "Include additional Morphir distributions as a dependency. Can be specified multiple times. Can be a path, url, or data-url.")
     .parse(process.argv)
 
 const dirAndOutput = program.opts()

--- a/package-lock.json
+++ b/package-lock.json
@@ -9256,7 +9256,8 @@
     "node_modules/neverthrow": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/neverthrow/-/neverthrow-6.2.1.tgz",
-      "integrity": "sha512-amlnNvPXmiUOmNsDfUngNWPdZYOmCUGExQy/kuPCmLbhrXVXIYhY4bnE4D3dWl7OMhSEr9NndUrl4aKGFhFIQg=="
+      "integrity": "sha512-amlnNvPXmiUOmNsDfUngNWPdZYOmCUGExQy/kuPCmLbhrXVXIYhY4bnE4D3dWl7OMhSEr9NndUrl4aKGFhFIQg==",
+      "license": "MIT"
     },
     "node_modules/next-tick": {
       "version": "1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,8 +19,10 @@
         "get-stdin": "^8.0.0",
         "inquirer": "^8.0.0",
         "log-timestamp": "^0.3.0",
+        "packageurl-js": "^1.2.1",
         "prettier": "^2.4.1",
-        "vis-network": "^9.1.2"
+        "vis-network": "^9.1.2",
+        "zod": "^3.23.8"
       },
       "bin": {
         "morphir": "cli2/lib/morphir.js",
@@ -9639,6 +9641,11 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/packageurl-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/packageurl-js/-/packageurl-js-1.2.1.tgz",
+      "integrity": "sha512-cZ6/MzuXaoFd16/k0WnwtI298UCaDHe/XlSh85SeOKbGZ1hq0xvNbx3ILyCMyk7uFQxl6scF3Aucj6/EO9NwcA=="
+    },
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -12906,6 +12913,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "redistributable/TypeSpec/sdk": {
@@ -20413,6 +20428,11 @@
         }
       }
     },
+    "packageurl-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/packageurl-js/-/packageurl-js-1.2.1.tgz",
+      "integrity": "sha512-cZ6/MzuXaoFd16/k0WnwtI298UCaDHe/XlSh85SeOKbGZ1hq0xvNbx3ILyCMyk7uFQxl6scF3Aucj6/EO9NwcA=="
+    },
     "pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -22937,6 +22957,11 @@
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
+    },
+    "zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,14 +14,18 @@
         "chalk": "^4.1.1",
         "commander": "^9.0.0",
         "cookie-parser": "^1.4.6",
+        "data-urls": "^5.0.0",
         "express": "^4.19.2",
         "fs-extra": "^9.1.0",
         "get-stdin": "^8.0.0",
+        "get-uri": "^6.0.3",
         "inquirer": "^8.0.0",
         "log-timestamp": "^0.3.0",
+        "neverthrow": "^6.2.1",
         "packageurl-js": "^1.2.1",
         "prettier": "^2.4.1",
         "vis-network": "^9.1.2",
+        "whatwg-encoding": "^3.1.1",
         "zod": "^3.23.8"
       },
       "bin": {
@@ -31,9 +35,11 @@
       },
       "devDependencies": {
         "@morphir/typespec-sdk": "file:redistributable/TypeSpec/sdk",
+        "@types/data-urls": "^3.0.4",
         "@types/inquirer": "^9.0.3",
         "@types/jest": "^27.4.0",
         "@types/mocha": "^9.0.0",
+        "@types/whatwg-encoding": "^2.0.3",
         "@typespec/compiler": "^0.42.0",
         "@vercel/ncc": "^0.38.1",
         "del-cli": "3.0.1",
@@ -1522,6 +1528,16 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/data-urls": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/data-urls/-/data-urls-3.0.4.tgz",
+      "integrity": "sha512-XRY2WVaOFSTKpNMaplqY1unPgAGk/DosOJ+eFrB6LJcFFbRH3nVbwJuGqLmDwdTWWx+V7U614/kmrj1JmCDl2A==",
+      "dev": true,
+      "dependencies": {
+        "@types/whatwg-mimetype": "*",
+        "@types/whatwg-url": "*"
+      }
+    },
     "node_modules/@types/glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
@@ -1640,6 +1656,33 @@
       "dev": true,
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/webidl-conversions": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
+      "dev": true
+    },
+    "node_modules/@types/whatwg-encoding": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-encoding/-/whatwg-encoding-2.0.3.tgz",
+      "integrity": "sha512-7TJfeaSFIWAKQ4ZynOb5zV3xzJQEEmL0U0j+uH7tnqfL97apXDTwMo0dB2uAWXAbr2dRRi5/eO9jV9dK/1GkiA==",
+      "dev": true
+    },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true
+    },
+    "node_modules/@types/whatwg-url": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
+      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/webidl-conversions": "*"
       }
     },
     "node_modules/@types/yargs": {
@@ -2561,6 +2604,14 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
+      "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/batch": {
@@ -3489,17 +3540,54 @@
       }
     },
     "node_modules/data-urls": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
-      "integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
-      "dev": true,
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
       "dependencies": {
-        "abab": "^2.0.3",
-        "whatwg-mimetype": "^2.3.0",
-        "whatwg-url": "^8.0.0"
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
+      "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.0.0.tgz",
+      "integrity": "sha512-1lfMEm2IEr7RIV+f4lUNPOqfFL+pO+Xw3fJSqmjX9AbXcXcYOkCe1P6+9VBZB6n94af16NfZf+sSk0JCBZC9aw==",
+      "dependencies": {
+        "tr46": "^5.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/debug": {
@@ -5106,6 +5194,62 @@
         "node": ">=6"
       }
     },
+    "node_modules/get-uri": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.3.tgz",
+      "integrity": "sha512-BzUrJBS9EcUb4cFol8r4W3v1cPsSyajLSthNkz5BxbpDcHN5tIrM10E2eNvfnvBn3DaT3DUgx0OpsBKkaOpanw==",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4",
+        "fs-extra": "^11.2.0"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/get-uri/node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/get-uri/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/get-uri/node_modules/fs-extra": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/get-uri/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
     "node_modules/get-value": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
@@ -6332,6 +6476,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/html-encoding-sniffer/node_modules/whatwg-encoding": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+      "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+      "dev": true,
+      "dependencies": {
+        "iconv-lite": "0.4.24"
       }
     },
     "node_modules/html-escaper": {
@@ -7881,6 +8034,20 @@
         }
       }
     },
+    "node_modules/jsdom/node_modules/data-urls": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
+      "integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
+      "dev": true,
+      "dependencies": {
+        "abab": "^2.0.3",
+        "whatwg-mimetype": "^2.3.0",
+        "whatwg-url": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/jsdom/node_modules/form-data": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
@@ -7893,6 +8060,15 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-encoding": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+      "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+      "dev": true,
+      "dependencies": {
+        "iconv-lite": "0.4.24"
       }
     },
     "node_modules/jsesc": {
@@ -9077,6 +9253,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/neverthrow": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/neverthrow/-/neverthrow-6.2.1.tgz",
+      "integrity": "sha512-amlnNvPXmiUOmNsDfUngNWPdZYOmCUGExQy/kuPCmLbhrXVXIYhY4bnE4D3dWl7OMhSEr9NndUrl4aKGFhFIQg=="
+    },
     "node_modules/next-tick": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
@@ -10079,9 +10260,9 @@
       }
     },
     "node_modules/punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "engines": {
         "node": ">=6"
       }
@@ -12550,12 +12731,25 @@
       }
     },
     "node_modules/whatwg-encoding": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
-      "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
-      "dev": true,
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
       "dependencies": {
-        "iconv-lite": "0.4.24"
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/whatwg-mimetype": {
@@ -14052,6 +14246,16 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/data-urls": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/data-urls/-/data-urls-3.0.4.tgz",
+      "integrity": "sha512-XRY2WVaOFSTKpNMaplqY1unPgAGk/DosOJ+eFrB6LJcFFbRH3nVbwJuGqLmDwdTWWx+V7U614/kmrj1JmCDl2A==",
+      "dev": true,
+      "requires": {
+        "@types/whatwg-mimetype": "*",
+        "@types/whatwg-url": "*"
+      }
+    },
     "@types/glob": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
@@ -14170,6 +14374,33 @@
       "dev": true,
       "requires": {
         "@types/node": "*"
+      }
+    },
+    "@types/webidl-conversions": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz",
+      "integrity": "sha512-CiJJvcRtIgzadHCYXw7dqEnMNRjhGZlYK05Mj9OyktqV8uVT8fD2BFOB7S1uwBE3Kj2Z+4UyPmFw/Ixgw/LAlA==",
+      "dev": true
+    },
+    "@types/whatwg-encoding": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-encoding/-/whatwg-encoding-2.0.3.tgz",
+      "integrity": "sha512-7TJfeaSFIWAKQ4ZynOb5zV3xzJQEEmL0U0j+uH7tnqfL97apXDTwMo0dB2uAWXAbr2dRRi5/eO9jV9dK/1GkiA==",
+      "dev": true
+    },
+    "@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true
+    },
+    "@types/whatwg-url": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.5.tgz",
+      "integrity": "sha512-coYR071JRaHa+xoEvvYqvnIHaVqaYrLPbsufM9BF63HkwI5Lgmy2QR8Q5K/lYDYo5AK82wOvSOS0UsLTpTG7uQ==",
+      "dev": true,
+      "requires": {
+        "@types/webidl-conversions": "*"
       }
     },
     "@types/yargs": {
@@ -14859,6 +15090,11 @@
           }
         }
       }
+    },
+    "basic-ftp": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
+      "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg=="
     },
     "batch": {
       "version": "0.6.1",
@@ -15622,14 +15858,41 @@
       "dev": true
     },
     "data-urls": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
-      "integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
-      "dev": true,
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
       "requires": {
-        "abab": "^2.0.3",
-        "whatwg-mimetype": "^2.3.0",
-        "whatwg-url": "^8.0.0"
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
+          "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
+          "requires": {
+            "punycode": "^2.3.1"
+          }
+        },
+        "webidl-conversions": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+          "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
+        },
+        "whatwg-mimetype": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+          "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="
+        },
+        "whatwg-url": {
+          "version": "14.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.0.0.tgz",
+          "integrity": "sha512-1lfMEm2IEr7RIV+f4lUNPOqfFL+pO+Xw3fJSqmjX9AbXcXcYOkCe1P6+9VBZB6n94af16NfZf+sSk0JCBZC9aw==",
+          "requires": {
+            "tr46": "^5.0.0",
+            "webidl-conversions": "^7.0.0"
+          }
+        }
       }
     },
     "debug": {
@@ -16897,6 +17160,47 @@
         "pump": "^3.0.0"
       }
     },
+    "get-uri": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.3.tgz",
+      "integrity": "sha512-BzUrJBS9EcUb4cFol8r4W3v1cPsSyajLSthNkz5BxbpDcHN5tIrM10E2eNvfnvBn3DaT3DUgx0OpsBKkaOpanw==",
+      "requires": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4",
+        "fs-extra": "^11.2.0"
+      },
+      "dependencies": {
+        "data-uri-to-buffer": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+          "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw=="
+        },
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "fs-extra": {
+          "version": "11.2.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+          "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
     "get-value": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
@@ -17869,6 +18173,17 @@
       "dev": true,
       "requires": {
         "whatwg-encoding": "^1.0.5"
+      },
+      "dependencies": {
+        "whatwg-encoding": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+          "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+          "dev": true,
+          "requires": {
+            "iconv-lite": "0.4.24"
+          }
+        }
       }
     },
     "html-escaper": {
@@ -19068,6 +19383,17 @@
         "xml-name-validator": "^3.0.0"
       },
       "dependencies": {
+        "data-urls": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
+          "integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
+          "dev": true,
+          "requires": {
+            "abab": "^2.0.3",
+            "whatwg-mimetype": "^2.3.0",
+            "whatwg-url": "^8.0.0"
+          }
+        },
         "form-data": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
@@ -19077,6 +19403,15 @@
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.8",
             "mime-types": "^2.1.12"
+          }
+        },
+        "whatwg-encoding": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
+          "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
+          "dev": true,
+          "requires": {
+            "iconv-lite": "0.4.24"
           }
         }
       }
@@ -19994,6 +20329,11 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
     },
+    "neverthrow": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/neverthrow/-/neverthrow-6.2.1.tgz",
+      "integrity": "sha512-amlnNvPXmiUOmNsDfUngNWPdZYOmCUGExQy/kuPCmLbhrXVXIYhY4bnE4D3dWl7OMhSEr9NndUrl4aKGFhFIQg=="
+    },
     "next-tick": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
@@ -20762,9 +21102,9 @@
       }
     },
     "punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
     },
     "qs": {
       "version": "6.11.0",
@@ -22688,12 +23028,21 @@
       "dev": true
     },
     "whatwg-encoding": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
-      "integrity": "sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==",
-      "dev": true,
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
       "requires": {
-        "iconv-lite": "0.4.24"
+        "iconv-lite": "0.6.3"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        }
       }
     },
     "whatwg-mimetype": {

--- a/package.json
+++ b/package.json
@@ -66,10 +66,10 @@
   "homepage": "https://github.com/Morgan-Stanley/morphir-elm#readme",
   "devDependencies": {
     "@morphir/typespec-sdk": "file:redistributable/TypeSpec/sdk",
+    "@types/data-urls": "^3.0.4",
     "@types/inquirer": "^9.0.3",
     "@types/jest": "^27.4.0",
     "@types/mocha": "^9.0.0",
-    "@types/data-urls": "^3.0.4",
     "@types/whatwg-encoding": "^2.0.3",
     "@typespec/compiler": "^0.42.0",
     "@vercel/ncc": "^0.38.1",
@@ -97,7 +97,6 @@
     "typescript": "^4.4.3"
   },
   "dependencies": {
-
     "ajv": "^8.10.0",
     "ajv-formats": "^2.1.1",
     "chalk": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,8 @@
     "@types/inquirer": "^9.0.3",
     "@types/jest": "^27.4.0",
     "@types/mocha": "^9.0.0",
+    "@types/data-urls": "^3.0.4",
+    "@types/whatwg-encoding": "^2.0.3",
     "@typespec/compiler": "^0.42.0",
     "@vercel/ncc": "^0.38.1",
     "del-cli": "3.0.1",
@@ -95,19 +97,24 @@
     "typescript": "^4.4.3"
   },
   "dependencies": {
+
     "ajv": "^8.10.0",
     "ajv-formats": "^2.1.1",
     "chalk": "^4.1.1",
     "commander": "^9.0.0",
     "cookie-parser": "^1.4.6",
+    "data-urls": "^5.0.0",
     "express": "^4.19.2",
     "fs-extra": "^9.1.0",
     "get-stdin": "^8.0.0",
+    "get-uri": "^6.0.3",
     "inquirer": "^8.0.0",
     "log-timestamp": "^0.3.0",
+    "neverthrow": "^6.2.1",
     "packageurl-js": "^1.2.1",
     "prettier": "^2.4.1",
     "vis-network": "^9.1.2",
+    "whatwg-encoding": "^3.1.1",
     "zod": "^3.23.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -105,7 +105,9 @@
     "get-stdin": "^8.0.0",
     "inquirer": "^8.0.0",
     "log-timestamp": "^0.3.0",
+    "packageurl-js": "^1.2.1",
     "prettier": "^2.4.1",
-    "vis-network": "^9.1.2"
+    "vis-network": "^9.1.2",
+    "zod": "^3.23.8"
   }
 }


### PR DESCRIPTION
# Feature - Dependency Management improvement

Improve how the Morphir CLI handles dependencies and add "includes" to allow providing dependencies at the command line

## Dependency Management Improvement

The Morphir CLI has had support for some time for models to depend on other models using `localDependencies` in their `morphir.json` file. While this feature is not particularly well documented, users who have taken advantage of this feature have hit on some difficulties. The primary issue is that the dependencies must be a local IR file, as each local dependency expected to be an existing Morphir IR on local disk (this means a JSON serialized Morphir IR File).

Users have expressed desires to be able to load dependencies from remote locations. Also, it would be nice if it were easier to share dependencies.

Ways we want to enable to load dependencies:

### Local Dependencies
- [x] file paths - Morphir IR JSON at a file path
- [x] [Data URLs](https://developer.mozilla.org/en-US/docs/web/http/basics_of_http/data_urls) - Morphir IR JSON encoded as a Data URL

### Remote Dependencies
- [x] - http(s) - Morphir IR JSON provided via http(s)
- [ ] - github - Morphir IR JSON at a github location and/or release
- [x] - ftp  - Morphir IR JSON at a FTP URL

NOTE: That to start we are focused on directly loading Morphir IR JSON files, but another feature we would look to support, but most likely not in this PR is to pull out the Morphir IR JSON files from a zip or tar archive as well as the more advanced function of triggering a build of the Morphir IR JSON given a dependency on a `morphir.json` project file which may be located at a local or remote location. 

## Includes

Includes allow you to support the use-cases mentioned above but using the `-I` command-line option. With the `-I` option it would be easy for example to inject additional IR includes to the `morphir make`, outside of what is provided in the `morphir.json` project file.

# Terms

> THIS SOFTWARE IS CONTRIBUTED SUBJECT TO THE TERMS OF THE TERMS OF THE CCLA DATED 2017-11-07 WITH FINOS/LINUX FOUNDATION (FORMERLY THE SYMPHONY SOFTWARE FOUNDATION CCLA).
>
> THIS SOFTWARE IS LICENSED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE AND ANY WARRANTY OF NON-INFRINGEMENT, ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THIS SOFTWARE MAY BE REDISTRIBUTED TO OTHERS ONLY BY EFFECTIVELY USING THIS OR ANOTHER EQUIVALENT DISCLAIMER IN ADDITION TO ANY OTHER REQUIRED LICENSE TERMS.
