### PR TITLE
Add workspace configuration for monorepo restructuring

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "morphir-elm",
   "version": "2.100.0",
   "description": "Elm bindings for Morphir",
+  "workspaces": [
+    "packages/*"
+  ],
   "type": "module",
   "module": "es6",
   "types": "morphir-ts/dist/",


### PR DESCRIPTION
## Summary

- Add `"workspaces": ["packages/*"]` to root package.json
- Create `packages/` directory with .gitkeep

This is Phase 0 of the monorepo restructuring epic (morphir-elm-qws). No components are moved — this just establishes the workspace configuration so subsequent PRs can move components into `packages/` one at a time.

## Test plan

- [x] `bun install` resolves workspace config without errors
- [x] `mise run build` passes (91s)
- [x] `mise run test:unit` passes (864 tests, 0 failures)
- [x] `mise run test:cli2` passes (29 tests, 0 failures)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)