### PR TITLE
Phase 3: Update docs for monorepo structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Morphir is a multi-language system for capturing business logic in a technology-
 
 ### Languages
 - **Elm** - Primary language for business logic and frontend tooling
-- **TypeScript** - CLI tooling (cli2/) and SDK (morphir-ts/)
+- **TypeScript** - CLI tooling (packages/cli2/) and SDK (packages/morphir-ts/)
 - **JavaScript** - CLI v1 and generated outputs
 
 ### Key Commands

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -105,10 +105,14 @@ npm run build:cli2     # Build CLI2 only
 │   └── setup/               # Setup subtasks
 │       ├── elm-tooling.ts
 │       └── morphir-jvm.ts
-cli/                         # CLI v1 (Elm + JavaScript)
-cli2/                        # CLI v2 (TypeScript + Elm)
-morphir-ts/                  # TypeScript SDK
-src/                         # Elm source code
+packages/                    # Workspace packages
+│   ├── cli/                 # CLI v1 (Elm + JavaScript)
+│   ├── cli2/                # CLI v2 (TypeScript + Elm)
+│   ├── morphir-ts/          # TypeScript SDK
+│   ├── server/              # Development server
+│   ├── cadl-frontend/       # CADL frontend
+│   └── decoration-extension/# VS Code decoration extension
+src/                         # Elm source code (shared root for Elm package)
 tests-integration/           # Integration tests
 ```
 


### PR DESCRIPTION
## Summary
- Update DEVELOPING.md project structure diagram to show `packages/` layout with all moved components
- Update AGENTS.md tech stack references from `cli2/` and `morphir-ts/` to `packages/cli2/` and `packages/morphir-ts/`
- Cleaned up leftover untracked build artifacts at root (`cli/`, `cli2/`, `morphir-ts/` directories)

Closes morphir-elm-8of (Phase 3: Documentation and CI/CD updates)

## Audit Results
- CI workflows: already correct (use mise tasks which handle paths internally)
- Root package.json `files` field: correctly references `packages/` paths
- `.gitignore`: correctly updated in prior phases
- No remaining stale path references found

🤖 Generated with [Claude Code](https://claude.com/claude-code)