### PR TITLE
Switch consumer packages to wildcard morphir-elm dep

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -62,7 +62,7 @@
         "@cadl-lang/compiler": "^0.35.0",
         "@cadl-lang/openapi3": "^0.15.0",
         "@cadl-lang/rest": "^0.17.0",
-        "morphir-elm": "^2.74.0",
+        "morphir-elm": "*",
         "npm": "^10.5.2",
         "path": "^0.12.7",
         "ts-node": "^10.9.1",
@@ -109,7 +109,7 @@
       "dependencies": {
         "comment-json": "^4.2.3",
         "jsonc-parser": "^3.2.0",
-        "morphir-elm": "^2.86.0",
+        "morphir-elm": "*",
       },
       "devDependencies": {
         "@types/glob": "^8.1.0",

--- a/packages/cadl-frontend/package.json
+++ b/packages/cadl-frontend/package.json
@@ -18,7 +18,7 @@
     "@cadl-lang/compiler": "^0.35.0",
     "@cadl-lang/openapi3": "^0.15.0",
     "@cadl-lang/rest": "^0.17.0",
-    "morphir-elm": "^2.74.0",
+    "morphir-elm": "*",
     "npm": "^10.5.2",
     "path": "^0.12.7",
     "ts-node": "^10.9.1",

--- a/packages/decoration-extension/package.json
+++ b/packages/decoration-extension/package.json
@@ -99,6 +99,6 @@
   "dependencies": {
     "comment-json": "^4.2.3",
     "jsonc-parser": "^3.2.0",
-    "morphir-elm": "^2.86.0"
+    "morphir-elm": "*"
   }
 }


### PR DESCRIPTION
## Summary
- Change `morphir-elm` dependency in cadl-frontend from `^2.74.0` to `*`
- Change `morphir-elm` dependency in decoration-extension from `^2.86.0` to `*`

Both are `private: true` workspace packages that import TypeScript types from `morphir-elm`. Since the root package is the workspace root (not a member), `workspace:*` can't be used — `*` is the correct specifier to always resolve to latest.

Closes morphir-elm-xz0

🤖 Generated with [Claude Code](https://claude.com/claude-code)