### PR TITLE
Fix stack overflow in morphir make for large value definitions

### DIFF
--- a/packages/cli/morphir-elm-make.js
+++ b/packages/cli/morphir-elm-make.js
@@ -1,6 +1,22 @@
 #!/usr/bin/env node
 'use strict'
 
+// Increase stack size for complex type inference (see GitHub issue #1258).
+// The Elm type solver uses deep recursion that exceeds Node.js default stack (~1MB)
+// on large value definitions. Re-exec with 8MB stack if needed.
+if (!process.env.__MORPHIR_STACK_EXPANDED) {
+    const { execFileSync } = require('child_process')
+    process.env.__MORPHIR_STACK_EXPANDED = '1'
+    try {
+        execFileSync(process.execPath, ['--stack-size=8192', ...process.argv.slice(1)], {
+            stdio: 'inherit',
+            env: process.env
+        })
+    } catch (e) {
+        process.exit(e.status || 1)
+    }
+    process.exit(0)
+}
 
 // NPM imports
 const commander = require('commander')

--- a/packages/cli2/morphir-make.ts
+++ b/packages/cli2/morphir-make.ts
@@ -1,5 +1,23 @@
 #!/usr/bin/env node
 
+// Increase stack size for complex type inference (see GitHub issue #1258).
+// The Elm type solver uses deep recursion that exceeds Node.js default stack (~1MB)
+// on large value definitions. Re-exec with 8MB stack if needed.
+import { execFileSync } from "child_process";
+
+if (!process.env.__MORPHIR_STACK_EXPANDED) {
+  process.env.__MORPHIR_STACK_EXPANDED = "1";
+  try {
+    execFileSync(process.execPath, ["--stack-size=8192", ...process.argv.slice(1)], {
+      stdio: "inherit",
+      env: process.env,
+    });
+  } catch (e: any) {
+    process.exit(e.status || 1);
+  }
+  process.exit(0);
+}
+
 // NPM imports
 import { Command } from 'commander'
 import { make } from './cliAPI.js'

--- a/src/Morphir/Type/MetaType.elm
+++ b/src/Morphir/Type/MetaType.elm
@@ -197,146 +197,322 @@ variables metaType =
             Set.empty
 
 
+{- Stack-safe substitution using an explicit continuation stack.
+
+   The original recursive versions of substituteVariable and substituteVariables
+   could overflow the JavaScript stack on deeply nested MetaType trees (see #1258).
+
+   The trampoline pattern works by:
+   1. Converting the tree traversal into a single tail-recursive function
+   2. Using an explicit stack of "frames" to track what work remains
+   3. Alternating between Process mode (descend into children) and Apply mode (combine results)
+
+   Elm's compiler optimizes self-tail-calls into while loops, so this uses O(1) stack space.
+-}
+
+
+{-| A frame on the explicit continuation stack. Each variant captures the context
+needed to reconstruct a parent node once its children have been processed.
+-}
+type SubstFrame
+    = -- Tuple: processed elements (reversed), remaining elements
+      TupleElems (List MetaType) (List MetaType)
+      -- Record: recordVar, isOpen, processed fields (reversed), current field name, remaining fields
+    | RecordFields Variable Bool (List ( Name, MetaType )) Name (List ( Name, MetaType ))
+      -- Fun: unprocessed second child (we're processing the first)
+    | FunLeft MetaType
+      -- Fun: processed first child (we're processing the second)
+    | FunRight MetaType
+      -- Ref: fQName, processed args (reversed), remaining args, maybe alias
+    | RefArgs FQName (List MetaType) (List MetaType) (Maybe MetaType)
+      -- Ref alias: fQName, processed args (alias is being processed)
+    | RefAlias FQName (List MetaType)
+
+
 substituteVariable : Variable -> MetaType -> MetaType -> MetaType
 substituteVariable var replacement original =
-    if variables original |> Set.member var then
-        case original of
-            MetaVar thisVar ->
-                if thisVar == var then
-                    replacement
+    substVarLoop var replacement True original []
 
-                else
-                    original
 
-            MetaTuple _ metaElems ->
-                metaTuple
-                    (metaElems
-                        |> List.map (substituteVariable var replacement)
-                    )
+{-| Tail-recursive loop for single-variable substitution.
+The Bool parameter indicates mode: True = Process (descend), False = Apply (combine).
+When processing, `current` is the node to examine.
+When applying, `current` is the result to combine with the stack.
+-}
+substVarLoop : Variable -> MetaType -> Bool -> MetaType -> List SubstFrame -> MetaType
+substVarLoop var replacement isProcess current stack =
+    if isProcess then
+        -- Process mode: examine current node and either produce a result or descend
+        if not (Set.member var (variables current)) then
+            substVarLoop var replacement False current stack
 
-            MetaRecord _ recordVar isOpen metaFields ->
-                if recordVar == var then
-                    case replacement of
-                        MetaVar replacementVar ->
-                            metaRecord replacementVar
-                                isOpen
-                                (metaFields
-                                    |> Dict.map
-                                        (\_ fieldType ->
-                                            substituteVariable var replacement fieldType
-                                        )
-                                )
+        else
+            case current of
+                MetaVar thisVar ->
+                    if thisVar == var then
+                        substVarLoop var replacement False replacement stack
 
-                        _ ->
-                            replacement
+                    else
+                        substVarLoop var replacement False current stack
 
-                else
-                    metaRecord recordVar
-                        isOpen
-                        (metaFields
-                            |> Dict.map
-                                (\_ fieldType ->
-                                    substituteVariable var replacement fieldType
-                                )
-                        )
+                MetaUnit ->
+                    substVarLoop var replacement False current stack
 
-            MetaFun _ metaFunc metaArg ->
-                metaFun
-                    (substituteVariable var replacement metaFunc)
-                    (substituteVariable var replacement metaArg)
+                MetaTuple _ metaElems ->
+                    case metaElems of
+                        [] ->
+                            substVarLoop var replacement False (metaTuple []) stack
 
-            MetaRef _ fQName args maybeAliasedType ->
-                case maybeAliasedType of
-                    Just aliasedType ->
-                        metaAlias fQName
-                            (args
-                                |> List.map (substituteVariable var replacement)
-                            )
-                            (substituteVariable var replacement aliasedType)
+                        first :: rest ->
+                            substVarLoop var replacement True first (TupleElems [] rest :: stack)
 
-                    Nothing ->
-                        metaRef fQName
-                            (args
-                                |> List.map (substituteVariable var replacement)
-                            )
+                MetaRecord _ recordVar isOpen metaFields ->
+                    let
+                        useVar =
+                            if recordVar == var then
+                                case replacement of
+                                    MetaVar replacementVar ->
+                                        Just replacementVar
 
-            MetaUnit ->
-                original
+                                    _ ->
+                                        Nothing
+
+                            else
+                                Just recordVar
+                    in
+                    case useVar of
+                        Nothing ->
+                            -- recordVar matches and replacement is not a MetaVar: return replacement
+                            substVarLoop var replacement False replacement stack
+
+                        Just rv ->
+                            case Dict.toList metaFields of
+                                [] ->
+                                    substVarLoop var replacement False (metaRecord rv isOpen Dict.empty) stack
+
+                                ( name, ft ) :: rest ->
+                                    substVarLoop var replacement True ft (RecordFields rv isOpen [] name rest :: stack)
+
+                MetaFun _ metaFunc metaArg ->
+                    substVarLoop var replacement True metaFunc (FunLeft metaArg :: stack)
+
+                MetaRef _ fQName args maybeAliasedType ->
+                    case args of
+                        [] ->
+                            case maybeAliasedType of
+                                Just alias ->
+                                    substVarLoop var replacement True alias (RefAlias fQName [] :: stack)
+
+                                Nothing ->
+                                    substVarLoop var replacement False (metaRef fQName []) stack
+
+                        first :: rest ->
+                            substVarLoop var replacement True first (RefArgs fQName [] rest maybeAliasedType :: stack)
 
     else
-        original
+        -- Apply mode: combine result with continuation stack
+        case stack of
+            [] ->
+                current
+
+            (TupleElems done remaining) :: restStack ->
+                let
+                    newDone =
+                        current :: done
+                in
+                case remaining of
+                    [] ->
+                        substVarLoop var replacement False (metaTuple (List.reverse newDone)) restStack
+
+                    next :: rest ->
+                        substVarLoop var replacement True next (TupleElems newDone rest :: restStack)
+
+            (RecordFields recordVar isOpen done currentName remaining) :: restStack ->
+                let
+                    newDone =
+                        ( currentName, current ) :: done
+                in
+                case remaining of
+                    [] ->
+                        substVarLoop var replacement False (metaRecord recordVar isOpen (Dict.fromList (List.reverse newDone))) restStack
+
+                    ( nextName, nextType ) :: rest ->
+                        substVarLoop var replacement True nextType (RecordFields recordVar isOpen newDone nextName rest :: restStack)
+
+            (FunLeft secondChild) :: restStack ->
+                substVarLoop var replacement True secondChild (FunRight current :: restStack)
+
+            (FunRight firstResult) :: restStack ->
+                substVarLoop var replacement False (metaFun firstResult current) restStack
+
+            (RefArgs fQName done remaining maybeAlias) :: restStack ->
+                let
+                    newDone =
+                        current :: done
+                in
+                case remaining of
+                    [] ->
+                        case maybeAlias of
+                            Just alias ->
+                                substVarLoop var replacement True alias (RefAlias fQName (List.reverse newDone) :: restStack)
+
+                            Nothing ->
+                                substVarLoop var replacement False (metaRef fQName (List.reverse newDone)) restStack
+
+                    next :: rest ->
+                        substVarLoop var replacement True next (RefArgs fQName newDone rest maybeAlias :: restStack)
+
+            (RefAlias fQName processedArgs) :: restStack ->
+                substVarLoop var replacement False (metaAlias fQName processedArgs current) restStack
 
 
 substituteVariables : Dict Variable MetaType -> MetaType -> MetaType
 substituteVariables replacements original =
-    if Set.isEmpty (Set.intersect (replacements |> Dict.keys |> Set.fromList) (variables original)) then
+    let
+        varSet =
+            replacements |> Dict.keys |> Set.fromList
+    in
+    if Set.isEmpty (Set.intersect varSet (variables original)) then
         original
 
     else
-        case original of
-            MetaVar thisVar ->
-                case Dict.get thisVar replacements of
-                    Just replacement ->
-                        replacement
+        substVarsLoop replacements varSet True original []
 
-                    Nothing ->
-                        original
 
-            MetaTuple _ metaElems ->
-                metaTuple
-                    (metaElems
-                        |> List.map (substituteVariables replacements)
-                    )
+{-| Tail-recursive loop for multi-variable substitution.
+Same structure as substVarLoop but checks against a set of variables.
+-}
+substVarsLoop : Dict Variable MetaType -> Set Variable -> Bool -> MetaType -> List SubstFrame -> MetaType
+substVarsLoop replacements varSet isProcess current stack =
+    if isProcess then
+        if Set.isEmpty (Set.intersect varSet (variables current)) then
+            substVarsLoop replacements varSet False current stack
 
-            MetaRecord _ recordVar isOpen metaFields ->
-                case Dict.get recordVar replacements of
-                    Just replacement ->
-                        case replacement of
-                            MetaVar replacementVar ->
-                                metaRecord replacementVar
-                                    isOpen
-                                    (metaFields
-                                        |> Dict.map
-                                            (\_ fieldType ->
-                                                substituteVariables replacements fieldType
-                                            )
-                                    )
+        else
+            case current of
+                MetaVar thisVar ->
+                    case Dict.get thisVar replacements of
+                        Just found ->
+                            substVarsLoop replacements varSet False found stack
 
-                            _ ->
-                                replacement
+                        Nothing ->
+                            substVarsLoop replacements varSet False current stack
 
-                    Nothing ->
-                        metaRecord recordVar
-                            isOpen
-                            (metaFields
-                                |> Dict.map
-                                    (\_ fieldType ->
-                                        substituteVariables replacements fieldType
-                                    )
-                            )
+                MetaUnit ->
+                    substVarsLoop replacements varSet False current stack
 
-            MetaFun _ metaFunc metaArg ->
-                metaFun
-                    (substituteVariables replacements metaFunc)
-                    (substituteVariables replacements metaArg)
+                MetaTuple _ metaElems ->
+                    case metaElems of
+                        [] ->
+                            substVarsLoop replacements varSet False (metaTuple []) stack
 
-            MetaRef _ fQName args maybeAliasedType ->
-                case maybeAliasedType of
-                    Just aliasedType ->
-                        metaAlias fQName
-                            (args
-                                |> List.map (substituteVariables replacements)
-                            )
-                            (substituteVariables replacements aliasedType)
+                        first :: rest ->
+                            substVarsLoop replacements varSet True first (TupleElems [] rest :: stack)
 
-                    Nothing ->
-                        metaRef fQName
-                            (args
-                                |> List.map (substituteVariables replacements)
-                            )
+                MetaRecord _ recordVar isOpen metaFields ->
+                    let
+                        useVar =
+                            case Dict.get recordVar replacements of
+                                Just found ->
+                                    case found of
+                                        MetaVar replacementVar ->
+                                            Just replacementVar
 
-            MetaUnit ->
-                original
+                                        _ ->
+                                            Nothing
+
+                                Nothing ->
+                                    Just recordVar
+                    in
+                    case useVar of
+                        Nothing ->
+                            -- recordVar found in replacements but replacement is not MetaVar
+                            case Dict.get recordVar replacements of
+                                Just found ->
+                                    substVarsLoop replacements varSet False found stack
+
+                                Nothing ->
+                                    -- unreachable, but handle gracefully
+                                    substVarsLoop replacements varSet False current stack
+
+                        Just rv ->
+                            case Dict.toList metaFields of
+                                [] ->
+                                    substVarsLoop replacements varSet False (metaRecord rv isOpen Dict.empty) stack
+
+                                ( name, ft ) :: rest ->
+                                    substVarsLoop replacements varSet True ft (RecordFields rv isOpen [] name rest :: stack)
+
+                MetaFun _ metaFunc metaArg ->
+                    substVarsLoop replacements varSet True metaFunc (FunLeft metaArg :: stack)
+
+                MetaRef _ fQName args maybeAliasedType ->
+                    case args of
+                        [] ->
+                            case maybeAliasedType of
+                                Just alias ->
+                                    substVarsLoop replacements varSet True alias (RefAlias fQName [] :: stack)
+
+                                Nothing ->
+                                    substVarsLoop replacements varSet False (metaRef fQName []) stack
+
+                        first :: rest ->
+                            substVarsLoop replacements varSet True first (RefArgs fQName [] rest maybeAliasedType :: stack)
+
+    else
+        case stack of
+            [] ->
+                current
+
+            (TupleElems done remaining) :: restStack ->
+                let
+                    newDone =
+                        current :: done
+                in
+                case remaining of
+                    [] ->
+                        substVarsLoop replacements varSet False (metaTuple (List.reverse newDone)) restStack
+
+                    next :: rest ->
+                        substVarsLoop replacements varSet True next (TupleElems newDone rest :: restStack)
+
+            (RecordFields recordVar isOpen done currentName remaining) :: restStack ->
+                let
+                    newDone =
+                        ( currentName, current ) :: done
+                in
+                case remaining of
+                    [] ->
+                        substVarsLoop replacements varSet False (metaRecord recordVar isOpen (Dict.fromList (List.reverse newDone))) restStack
+
+                    ( nextName, nextType ) :: rest ->
+                        substVarsLoop replacements varSet True nextType (RecordFields recordVar isOpen newDone nextName rest :: restStack)
+
+            (FunLeft secondChild) :: restStack ->
+                substVarsLoop replacements varSet True secondChild (FunRight current :: restStack)
+
+            (FunRight firstResult) :: restStack ->
+                substVarsLoop replacements varSet False (metaFun firstResult current) restStack
+
+            (RefArgs fQName done remaining maybeAlias) :: restStack ->
+                let
+                    newDone =
+                        current :: done
+                in
+                case remaining of
+                    [] ->
+                        case maybeAlias of
+                            Just alias ->
+                                substVarsLoop replacements varSet True alias (RefAlias fQName (List.reverse newDone) :: restStack)
+
+                            Nothing ->
+                                substVarsLoop replacements varSet False (metaRef fQName (List.reverse newDone)) restStack
+
+                    next :: rest ->
+                        substVarsLoop replacements varSet True next (RefArgs fQName newDone rest maybeAlias :: restStack)
+
+            (RefAlias fQName processedArgs) :: restStack ->
+                substVarsLoop replacements varSet False (metaAlias fQName processedArgs current) restStack
 
 
 boolType : MetaType


### PR DESCRIPTION
## Summary

Fixes #1258 — `morphir-elm make` crashes with "Maximum call stack size exceeded" when processing functions with many partially-applied arguments (e.g., `outflowRules` with 24 rules in morphir-examples).

## Root Cause

The Elm type solver's `substituteVariable` and `substituteVariables` functions in `Morphir.Type.MetaType` use non-tail-recursive tree traversal. During type inference, the constraint solver (`addSolution` → `unifyMetaType` → `mergeSolutions` → `addSolution`) creates mutually recursive call chains. For large value definitions with many type constraints, this exceeds Node.js's default stack size (~1MB).

## Fix

Two-layer defense:

1. **Trampoline (root cause fix):** Converted `substituteVariable` and `substituteVariables` from direct recursion to tail-recursive loops with explicit continuation stacks. Elm's compiler optimizes these to `while` loops in JavaScript, eliminating stack overflow regardless of MetaType tree depth. Uses a `SubstFrame` union type to track pending work (tuple elements, record fields, function args, ref args, aliases).

2. **Stack size increase (safety net):** Re-execute the `make` subcommand process with `--stack-size=8192` (8MB stack) when not already expanded. This guards against other deep recursion paths that may exist elsewhere in the type solver. Applied to both CLI v1 (`morphir-elm-make.js`) and CLI v2 (`morphir-make.ts`).

## Test plan

- [ ] Verify `morphir-elm make` succeeds on [morphir-examples v0.1.0](https://github.com/finos/morphir-examples/tree/v0.1.0) which previously crashed
- [ ] Verify existing `mise run build` and `mise run test` still pass
- [ ] Verify all 864 Elm unit tests pass
- [ ] Verify compiled JS uses `continue` loops (no recursive calls) for `substVarLoop`/`substVarsLoop`