### PR TITLE
Remove WASI dependencies from WASM interpreter

### DIFF
--- a/.mise/tasks/build/interpreter-wasm.ts
+++ b/.mise/tasks/build/interpreter-wasm.ts
@@ -76,11 +76,15 @@ await writeFile(bundlePath, bundled);
 
 log("build:interpreter-wasm", "Building WASM component...");
 
+// Disable WASI features we don't need — our interpreter is a pure computation
+// component with no I/O requirements. This avoids requiring wasi:http, wasi:io,
+// wasi:clocks, etc. which cause issues for consumers using WASI-compatible runtimes.
 await exec("npx", [
   "jco", "componentize",
   "build/interpreter-bundle.js",
   "--wit", "wit/",
   "--world-name", "interpreter",
+  "--disable", "all",
   "-o", "build/interpreter.wasm",
 ], { cwd: pkgDir });
 


### PR DESCRIPTION
## Summary
- Add `--disable all` to `jco componentize` to produce a pure computation component
- Removes all WASI imports (wasi:http, wasi:io, wasi:clocks, wasi:random) that were added by ComponentizeJS defaults
- The interpreter only exports `morphir:interpreter/types` and `morphir:interpreter/eval` — no imports needed

## Before
```
world root {
  import wasi:http/...
  import wasi:io/...
  import wasi:clocks/...
  import wasi:random/...
  export morphir:interpreter/types;
  export morphir:interpreter/eval;
}
```

## After
```
world root {
  export morphir:interpreter/types;
  export morphir:interpreter/eval;
}
```

## Test plan
- [x] `mise run build:interpreter-wasm` builds successfully
- [x] `mise run test:interpreter-wasm` — 11 tests pass, 38 assertions
- [x] `npx jco wit` confirms zero imports