### PR TITLE
Fix mise build pipeline on Windows

### DIFF
--- a/.mise/tasks/_lib.ts
+++ b/.mise/tasks/_lib.ts
@@ -4,12 +4,12 @@
  */
 
 import { $ } from "bun";
-import { join } from "path";
+import { join, isAbsolute, relative, sep } from "path";
 import { mkdir, rm, readFile, writeFile, copyFile } from "fs/promises";
 import { existsSync } from "fs";
 
 // Re-export common utilities
-export { $, join, mkdir, rm, readFile, writeFile, copyFile, existsSync };
+export { $, join, isAbsolute, relative, sep, mkdir, rm, readFile, writeFile, copyFile, existsSync };
 
 // Project root directory (where mise.toml lives)
 export const ROOT_DIR = join(import.meta.dir, "../..");
@@ -156,7 +156,7 @@ export async function del(patterns: string | string[]): Promise<void> {
   const patternList = Array.isArray(patterns) ? patterns : [patterns];
 
   for (const pattern of patternList) {
-    const fullPath = pattern.startsWith("/") ? pattern : join(ROOT_DIR, pattern);
+    const fullPath = isAbsolute(pattern) ? pattern : join(ROOT_DIR, pattern);
     if (existsSync(fullPath)) {
       await rm(fullPath, { recursive: true, force: true });
       console.log(`Deleted: ${pattern}`);
@@ -178,7 +178,7 @@ export async function copyGlob(
   await mkdir(destDir, { recursive: true });
 
   for await (const file of glob.scan({ cwd, absolute: true })) {
-    const relativePath = file.replace(cwd, "").replace(/^\//, "");
+    const relativePath = relative(cwd, file);
     const destPath = join(destDir, relativePath);
     await mkdir(join(destPath, ".."), { recursive: true });
     await copyFile(file, destPath);
@@ -192,7 +192,7 @@ export async function concat(files: string[], outputPath: string): Promise<void>
   const contents: string[] = [];
 
   for (const file of files) {
-    const fullPath = file.startsWith("/") ? file : join(ROOT_DIR, file);
+    const fullPath = isAbsolute(file) ? file : join(ROOT_DIR, file);
     const content = await readFile(fullPath, "utf-8");
     contents.push(content);
   }

--- a/.mise/tasks/build/morphir-ts.ts
+++ b/.mise/tasks/build/morphir-ts.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env bun
 //MISE description="Build Morphir TypeScript library"
-//MISE depends=["build:cli"]
+//MISE depends=["build:cli", "build:cli2"]
 
 import { del, morphirMake, morphirGen, exec, log, PATHS, ROOT_DIR, copyGlob, join } from "../_lib.ts";
 


### PR DESCRIPTION
## Summary

The mise/Bun build pipeline introduced in #850bb4471 fails on Windows due to POSIX-only assumptions in `.mise/tasks/_lib.ts` and a missing task dependency. This PR makes `mise run default` succeed on Windows without affecting macOS/Linux behaviour.

## Root causes

1. **Absolute-path detection assumed POSIX.** `del`, `concat`, and `copyGlob` checked `path.startsWith("/")` to decide whether a path was absolute. On Windows, absolute paths begin with a drive letter, so the check returned false and `ROOT_DIR` was prepended a second time, producing doubled paths like `D:\…\morphir-elm\D:\…\cli\web\insight.js`. This is what crashed `build:components` with ENOENT.

2. **Separator stripping in `copyGlob` was POSIX-only.** After `Bun.Glob.scan` returned absolute paths, the relative portion was extracted via `file.replace(cwd, "").replace(/^\//, "")` — which leaves a leading backslash on Windows.

3. **Missing task dependency.** `build:morphir-ts` depended on `build:cli` only, but its `morphir gen -t TypeScript` step shells out through `cli2/lib/morphir-typescript-gen.js`, which requires `cli2/Morphir.Elm.CLI.cjs` produced by `build:cli2`. The edge was implicit, and the mise scheduler happened to satisfy it on macOS; on Windows it didn't, causing `Cannot find module './../Morphir.Elm.CLI.cjs'`. This was a latent race, not strictly a Windows bug.

## Changes

- `.mise/tasks/_lib.ts` — use `path.isAbsolute()` in `del`, `concat`, and `copyGlob`; use `path.relative()` in `copyGlob` instead of the hand-rolled prefix strip.
- `.mise/tasks/build/morphir-ts.ts` — add `build:cli2` to the `depends` list.

## Test plan

- [x] `mise run build` succeeds on Windows
- [x] `mise run default` (clean → check → setup → build) succeeds on Windows
- [ ] Verify `mise run default` still succeeds on macOS / Linux (no behavioural change expected — `path.isAbsolute()` and `path.relative()` are cross-platform, and the new dependency edge only constrains scheduling)