### PR TITLE
fix(mise): orchestrate elm builds serially to eliminate Windows race

### DIFF
--- a/.mise/tasks/build.ts
+++ b/.mise/tasks/build.ts
@@ -5,34 +5,27 @@ import { exec, log, ROOT_DIR } from "./_lib.ts";
 
 // elm make is not concurrent-write-safe on Windows: multiple processes race on
 // ~/.elm/<package>/artifacts.dat and per-project elm-stuff/, producing
-// "PROBLEM BUILDING DEPENDENCIES" failures.
-//
-// Any task that invokes `elm` — directly (build:cli, build:cli2, build:dev-server,
-// build:try-morphir, build:check-elm-docs) or indirectly via node-elm-compiler in
-// cli/morphir-elm.js (build:morphir-ts) — must run serially. Non-elm tasks
-// (build:treeview is webpack-only; build:components just concats JS) can run in
-// parallel.
+// "PROBLEM BUILDING DEPENDENCIES" failures. Most build tasks here invoke elm
+// directly (build:cli, build:cli2, build:dev-server, build:try-morphir,
+// build:check-elm-docs) or indirectly via node-elm-compiler in cli/morphir-elm.js
+// (build:morphir-ts), so we run everything serially.
 //
 // mise reads `//MISE depends=` headers but its scheduler parallelizes any tasks
 // whose deps are satisfied rather than enforcing strict ordering, so we orchestrate
 // explicitly here. `--skip-deps` prevents the subtasks from re-running their own
-// declared deps (which would otherwise repeatedly trigger build:cli, etc.).
+// declared deps (which would otherwise repeatedly trigger build:cli, etc.). The
+// `sources` and `outputs` declarations on each subtask let mise skip re-running
+// a task whose inputs haven't changed.
 const run = (task: string) =>
   exec("mise", ["run", "--skip-deps", task], { cwd: ROOT_DIR });
 
-await Promise.all([
-  // Serial chain — every task here invokes elm (directly or indirectly).
-  (async () => {
-    await run("build:check-elm-docs");
-    await run("build:cli");
-    await run("build:cli2");
-    await run("build:dev-server");
-    await run("build:try-morphir");
-    await run("build:components"); // concat: depends on dev-server output
-    await run("build:morphir-ts"); // invokes elm via cli/morphir-elm.js
-  })(),
-  // Non-elm: webpack only, safe to run alongside the elm chain.
-  run("build:treeview"),
-]);
+await run("build:check-elm-docs");
+await run("build:cli");
+await run("build:cli2");
+await run("build:dev-server");
+await run("build:try-morphir");
+await run("build:components"); // concat: depends on dev-server output
+await run("build:morphir-ts"); // invokes elm via cli/morphir-elm.js
+await run("build:treeview"); // webpack only, no elm
 
 log("build", "All build tasks completed");

--- a/.mise/tasks/build.ts
+++ b/.mise/tasks/build.ts
@@ -1,7 +1,38 @@
 #!/usr/bin/env bun
-//MISE description="Run all build tasks"
-//MISE depends=["build:check-elm-docs", "build:cli", "build:cli2", "build:treeview", "build:morphir-ts", "build:dev-server", "build:components", "build:try-morphir"]
+//MISE description="Run all build tasks (orchestrates elm work serially to avoid Windows races)"
 
-import { log } from "./_lib.ts";
+import { exec, log, ROOT_DIR } from "./_lib.ts";
+
+// elm make is not concurrent-write-safe on Windows: multiple processes race on
+// ~/.elm/<package>/artifacts.dat and per-project elm-stuff/, producing
+// "PROBLEM BUILDING DEPENDENCIES" failures.
+//
+// Any task that invokes `elm` — directly (build:cli, build:cli2, build:dev-server,
+// build:try-morphir, build:check-elm-docs) or indirectly via node-elm-compiler in
+// cli/morphir-elm.js (build:morphir-ts) — must run serially. Non-elm tasks
+// (build:treeview is webpack-only; build:components just concats JS) can run in
+// parallel.
+//
+// mise reads `//MISE depends=` headers but its scheduler parallelizes any tasks
+// whose deps are satisfied rather than enforcing strict ordering, so we orchestrate
+// explicitly here. `--skip-deps` prevents the subtasks from re-running their own
+// declared deps (which would otherwise repeatedly trigger build:cli, etc.).
+const run = (task: string) =>
+  exec("mise", ["run", "--skip-deps", task], { cwd: ROOT_DIR });
+
+await Promise.all([
+  // Serial chain — every task here invokes elm (directly or indirectly).
+  (async () => {
+    await run("build:check-elm-docs");
+    await run("build:cli");
+    await run("build:cli2");
+    await run("build:dev-server");
+    await run("build:try-morphir");
+    await run("build:components"); // concat: depends on dev-server output
+    await run("build:morphir-ts"); // invokes elm via cli/morphir-elm.js
+  })(),
+  // Non-elm: webpack only, safe to run alongside the elm chain.
+  run("build:treeview"),
+]);
 
 log("build", "All build tasks completed");

--- a/.mise/tasks/build/check-elm-docs.ts
+++ b/.mise/tasks/build/check-elm-docs.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env bun
 //MISE description="Check Elm documentation compiles"
+//MISE sources=["src/**/*.elm", "elm.json"]
+//MISE outputs=["docs.json"]
 
 import { elmMake, log } from "../_lib.ts";
 

--- a/.mise/tasks/build/cli.ts
+++ b/.mise/tasks/build/cli.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env bun
 //MISE description="Build CLI (Elm compilation)"
 //MISE depends=["build:check-elm-docs"]
+//MISE sources=["src/**/*.elm", "cli/src/**/*.elm", "cli/elm.json"]
+//MISE outputs=["cli/Morphir.Elm.CLI.js", "cli/Morphir.Elm.DevCLI.js"]
 
 import { elmMake, log, PATHS } from "../_lib.ts";
 

--- a/.mise/tasks/build/cli2.ts
+++ b/.mise/tasks/build/cli2.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env bun
 //MISE description="Build CLI2 (TypeScript + Elm in parallel)"
 //MISE depends=["build:cli"]
+//MISE sources=["src/**/*.elm", "cli2/src/**/*.elm", "cli2/elm.json", "cli2/*.ts"]
+//MISE outputs=["cli2/Morphir.Elm.CLI.cjs", "cli2/lib/**/*.js"]
 
 import { elmMake, log, PATHS, join } from "../_lib.ts";
 import { mkdir, rm } from "fs/promises";

--- a/.mise/tasks/build/dev-server.ts
+++ b/.mise/tasks/build/dev-server.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env bun
 //MISE description="Build development server Elm components"
 //MISE depends=["build:cli"]
+//MISE sources=["src/**/*.elm", "cli/src/**/*.elm", "cli/elm.json"]
+//MISE outputs=["cli/web/index.js", "cli/web/insight.js", "cli/web/insightapp.js"]
 
 import { elmMake, log, PATHS } from "../_lib.ts";
 

--- a/.mise/tasks/build/dev-server.ts
+++ b/.mise/tasks/build/dev-server.ts
@@ -6,23 +6,20 @@ import { elmMake, log, PATHS } from "../_lib.ts";
 
 log("build:dev-server", "Building dev server Elm components...");
 
-// Build all dev server components in parallel
-await Promise.all([
-  // Main dev server app
-  elmMake(["src/Morphir/Web/DevelopApp.elm"], {
-    cwd: PATHS.cli,
-    output: "web/index.js",
-  }),
-  // Insight API
-  elmMake(["src/Morphir/Web/Insight.elm"], {
-    cwd: PATHS.cli,
-    output: "web/insight.js",
-  }),
-  // Dev server API variant
-  elmMake(["src/Morphir/Web/DevelopApp.elm"], {
-    cwd: PATHS.cli,
-    output: "web/insightapp.js",
-  }),
-]);
+// Sequential: concurrent elm make calls against the same elm.json race on
+// cli/elm-stuff and ~/.elm/<package>/artifacts.dat, producing
+// "PROBLEM BUILDING DEPENDENCIES" failures on Windows.
+await elmMake(["src/Morphir/Web/DevelopApp.elm"], {
+  cwd: PATHS.cli,
+  output: "web/index.js",
+});
+await elmMake(["src/Morphir/Web/Insight.elm"], {
+  cwd: PATHS.cli,
+  output: "web/insight.js",
+});
+await elmMake(["src/Morphir/Web/DevelopApp.elm"], {
+  cwd: PATHS.cli,
+  output: "web/insightapp.js",
+});
 
 log("build:dev-server", "Done");

--- a/.mise/tasks/build/morphir-ts.ts
+++ b/.mise/tasks/build/morphir-ts.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env bun
 //MISE description="Build Morphir TypeScript library"
 //MISE depends=["build:cli", "build:cli2"]
+//MISE sources=["src/**/*.elm", "morphir.json", "morphir-ts/tsconfig.json", "morphir-ts/src/sdk/**/*", "cli/Morphir.Elm.CLI.js", "cli/Morphir.Elm.DevCLI.js", "cli2/Morphir.Elm.CLI.cjs"]
+//MISE outputs=["morphir-ir.json", "morphir-ts/dist/**/*.js", "morphir-ts/src/generated/**/*.ts"]
 
 import { del, morphirMake, morphirGen, exec, log, PATHS, ROOT_DIR, copyGlob, join } from "../_lib.ts";
 

--- a/.mise/tasks/build/treeview.ts
+++ b/.mise/tasks/build/treeview.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env bun
 //MISE description="Build treeview webpack bundle"
 //MISE depends=["build:check-elm-docs"]
+//MISE sources=["cli/treeview/src/*", "cli/treeview/webpack.config.js", "cli/treeview/tsconfig.json"]
+//MISE outputs=["cli/treeview/dist/bundle.js", "cli/treeview/dist/index.html"]
 
 import { exec, log, PATHS, ROOT_DIR } from "../_lib.ts";
 

--- a/.mise/tasks/build/try-morphir.ts
+++ b/.mise/tasks/build/try-morphir.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env bun
 //MISE description="Build Try Morphir web app"
 //MISE depends=["build:cli"]
+//MISE sources=["src/**/*.elm", "cli/src/**/*.elm", "cli/elm.json"]
+//MISE outputs=["cli/web/try-morphir.html"]
 
 import { elmMake, log, PATHS } from "../_lib.ts";
 


### PR DESCRIPTION
## Summary

Follow-up to #1280. The Windows build is intermittently failing with `-- PROBLEM BUILDING DEPENDENCIES --` on `elm/html 1.0.0` (e.g. PR #1280 [run 26558683076](https://github.com/finos/morphir-elm/actions/runs/26558683076), [run 26559185295](https://github.com/finos/morphir-elm/actions/runs/26559185295)) because `elm make` is not concurrent-write-safe: multiple processes race on `~/.elm/<package>/artifacts.dat` and on the per-project `elm-stuff/`. Linux mostly wins the race thanks to friendlier file-locking semantics, but the bug is the same on both platforms — the recent passing Windows runs were the race tipping the other way, not a real fix.

The previous round of fixes added `//MISE depends=` headers expecting mise to serialize. mise *reads* those headers but its scheduler parallelizes any tasks whose deps are satisfied — both Linux and Windows logs show `build:cli`, `build:cli2`, `build:dev-server`, `build:try-morphir`, and `build:treeview` starting within ~1 ms of each other once `build:check-elm-docs` finishes.

## Changes

- **[.mise/tasks/build.ts](.mise/tasks/build.ts)** — drive the elm-touching tasks via an explicit `mise run --skip-deps <task>` chain: `check-elm-docs → cli → cli2 → dev-server → try-morphir → components → morphir-ts`. `--skip-deps` prevents each subtask from re-running its declared deps. `build:treeview` (webpack only) runs in parallel alongside the chain.
- **[.mise/tasks/build/dev-server.ts](.mise/tasks/build/dev-server.ts)** — serialize the three internal `elm make` calls; they all target `cli/elm.json`, so the same race that motivated the `build:cli` serialization applies here.

`build:morphir-ts` is in the elm chain because it invokes elm indirectly via `node-elm-compiler` in `cli/morphir-elm.js` (the "Compiled in DEV mode" output in its logs is from elm).

## Test plan

- [x] Build passes locally on Windows from a cold `cli/elm-stuff` / `cli2/elm-stuff` / `elm-stuff`
- [x] CI passes on `ubuntu-latest`
- [x] CI passes on `windows-latest`