### PR TITLE
fix(cli): guard Node 24 EBADF fd-close-on-GC crash and fix get-uri fd leak (#1282)

### DIFF
--- a/cli/cli.js
+++ b/cli/cli.js
@@ -1,5 +1,8 @@
 'use strict'
 
+// Guard against Node 24 EBADF double-close on GC (finos/morphir-elm#1282)
+require('./ebadf-guard')
+
 // NPM imports
 const path = require('path')
 const util = require('util')

--- a/cli/ebadf-guard.js
+++ b/cli/ebadf-guard.js
@@ -1,0 +1,25 @@
+'use strict';
+
+/**
+ * Guard against Node 24 fatal EBADF on FileHandle GC (finos/morphir-elm#1282).
+ *
+ * Since Node 24 (DEP0137 EOL, https://github.com/nodejs/node/pull/58536),
+ * a `fs.FileHandle` that is garbage-collected without an explicit `close()`
+ * throws a fatal uncaughtException with `code === 'EBADF'` and
+ * `syscall === 'close'` (message: "Closing file descriptor X on garbage
+ * collection failed, close") instead of the previous deprecation warning.
+ * The CLI's work has already completed successfully when this fires during
+ * wind-down, so the process dying with exit 1 breaks build systems.
+ *
+ * This guard swallows exactly that error shape and re-throws everything else.
+ * It is idempotent across multiple `require()` calls via a global flag.
+ */
+if (!globalThis.__morphirEbadfGuardInstalled) {
+  globalThis.__morphirEbadfGuardInstalled = true;
+  process.on('uncaughtException', (err) => {
+    if (err && err.code === 'EBADF' && err.syscall === 'close') {
+      return;
+    }
+    throw err;
+  });
+}

--- a/cli/ebadf-guard.js
+++ b/cli/ebadf-guard.js
@@ -11,13 +11,23 @@
  * The CLI's work has already completed successfully when this fires during
  * wind-down, so the process dying with exit 1 breaks build systems.
  *
- * This guard swallows exactly that error shape and re-throws everything else.
+ * This guard swallows exactly that GC diagnostic and re-throws everything
+ * else. An ordinary double-close via `fs.close()` callback has the same
+ * `EBADF`/`close` fields but without the GC message, so it must not be
+ * swallowed — it indicates a real resource-handling bug while work is still
+ * in progress.
  * It is idempotent across multiple `require()` calls via a global flag.
  */
 if (!globalThis.__morphirEbadfGuardInstalled) {
   globalThis.__morphirEbadfGuardInstalled = true;
   process.on('uncaughtException', (err) => {
-    if (err && err.code === 'EBADF' && err.syscall === 'close') {
+    if (
+      err &&
+      err.code === 'EBADF' &&
+      err.syscall === 'close' &&
+      typeof err.message === 'string' &&
+      err.message.includes('garbage collection')
+    ) {
       return;
     }
     throw err;

--- a/cli/morphir-dapr.js
+++ b/cli/morphir-dapr.js
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 'use strict'
 
+// Guard against Node 24 EBADF double-close on GC (finos/morphir-elm#1282)
+require('./ebadf-guard')
+
 // NPM imports
 const path = require('path')
 const util = require('util')

--- a/cli/morphir-elm-develop.js
+++ b/cli/morphir-elm-develop.js
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 "use strict";
 
+// Guard against Node 24 EBADF double-close on GC (finos/morphir-elm#1282)
+require('./ebadf-guard');
+
 // NPM imports
 const path = require("path");
 const util = require("util");

--- a/cli/morphir-elm-gen.js
+++ b/cli/morphir-elm-gen.js
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 'use strict'
 
+// Guard against Node 24 EBADF double-close on GC (finos/morphir-elm#1282)
+require('./ebadf-guard')
+
 // NPM imports
 const path = require('path')
 const commander = require('commander')

--- a/cli/morphir-elm-make.js
+++ b/cli/morphir-elm-make.js
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 'use strict'
 
+// Guard against Node 24 EBADF double-close on GC (finos/morphir-elm#1282)
+require('./ebadf-guard')
+
 
 // NPM imports
 const commander = require('commander')

--- a/cli/morphir-elm-test.js
+++ b/cli/morphir-elm-test.js
@@ -2,6 +2,9 @@
 
 'use strict'
 
+// Guard against Node 24 EBADF double-close on GC (finos/morphir-elm#1282)
+require('./ebadf-guard')
+
 // NPM imports
 const commander = require('commander')
 const cli = require('./cli')

--- a/cli/morphir-elm-treeview.js
+++ b/cli/morphir-elm-treeview.js
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 "use strict";
 
+// Guard against Node 24 EBADF double-close on GC (finos/morphir-elm#1282)
+require('./ebadf-guard');
+
 // NPM imports
 const path = require("path");
 const util = require("util");

--- a/cli/morphir-elm.js
+++ b/cli/morphir-elm.js
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 'use strict'
 
+// Guard against Node 24 EBADF double-close on GC (finos/morphir-elm#1282)
+require('./ebadf-guard')
+
 // NPM imports
 const path = require('path')
 const commander = require('commander')

--- a/cli/morphir.js
+++ b/cli/morphir.js
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
 'use strict'
 
+// Guard against Node 24 EBADF double-close on GC (finos/morphir-elm#1282)
+require('./ebadf-guard')
+
 // NPM imports
 const path = require('path')
 const commander = require('commander')

--- a/cli2/cli.ts
+++ b/cli2/cli.ts
@@ -1,4 +1,5 @@
-#!/usr/bin/env node
+// Guard against Node 24 EBADF double-close on GC (finos/morphir-elm#1282)
+import "./ebadf-guard.js";
 
 import * as fs from "fs";
 import * as util from "util";

--- a/cli2/cliAPI.ts
+++ b/cli2/cliAPI.ts
@@ -1,3 +1,6 @@
+// Guard against Node 24 EBADF double-close on GC (finos/morphir-elm#1282)
+import "./ebadf-guard.js";
+
 import * as cli from './cli.js'
 
 

--- a/cli2/dependencies.ts
+++ b/cli2/dependencies.ts
@@ -1,14 +1,13 @@
 import * as fs from "fs";
 import { ResultAsync } from "neverthrow";
 import * as path from "path";
-import { pathToFileURL } from "url";
+import { fileURLToPath, pathToFileURL } from "url";
 import * as util from "util";
 import { decode, labelToName } from "whatwg-encoding";
 import { z } from "zod";
 import { fetchUriToJson } from "./get-uri-wrapper.js";
-import { Readable } from "stream";
 import parseDataUrl from "data-urls";
-const fsReadFile = util.promisify(fs.readFile);
+import { promises as fsPromises } from "fs";
 
 export const DataUrl = z.string().trim().transform((val, ctx) => {
   const parsed = parseDataUrl(val)
@@ -186,7 +185,7 @@ const loadDependenciesFromString = (config: DependencyConfig) => function (input
     let { success: fileSuccess, data: fileData } = FileUrl.safeParse(sanitized);
     if (fileSuccess && fileData !== undefined) {
       console.info("Loading file url", fileData);
-      return fetchUriToJson(fileData)
+      return readLocalFileJson(fileData);
 
     }
     let { success: urlSuccess, data: urlData } = Url.safeParse(sanitized);
@@ -199,7 +198,7 @@ const loadDependenciesFromString = (config: DependencyConfig) => function (input
     if (localFileCWDSuccess && localUrlCWDData !== undefined) {
 
       console.info("Loading local file url from current working directory ", localUrlCWDData);
-      return fetchUriToJson(localUrlCWDData);
+      return readLocalFileJson(localUrlCWDData);
 
     }
 
@@ -207,7 +206,7 @@ const loadDependenciesFromString = (config: DependencyConfig) => function (input
     if (localFileSuccess && localUrlData !== undefined) {
 
       console.info("Loading local file url from morphir.json directory", localUrlData);
-      return fetchUriToJson(localUrlData);
+      return readLocalFileJson(localUrlData);
 
     }
 
@@ -263,11 +262,15 @@ class LocalDependencyNotFound extends Error {
 
 }
 
-
-async function toBuffer(stream: Readable): Promise<Buffer> {
-  const chunks: Buffer[] = [];
-  for await (const chunk of stream) {
-    chunks.push(chunk);
-  }
-  return Buffer.concat(chunks as unknown as Uint8Array[]);
+/**
+ * Read a local file:// URL directly via fs/promises instead of get-uri.
+ * This avoids get-uri's file.js path which opens an fd via fs-extra, then
+ * creates a ReadStream without guaranteeing the fd is closed if fstat fails
+ * or if the stream is not fully consumed. That leaked fd surfaces under
+ * Node 24 as a fatal EBADF close-on-GC (finos/morphir-elm#1282).
+ */
+async function readLocalFileJson(url: URL): Promise<unknown> {
+  const filePath = fileURLToPath(url);
+  const content = await fsPromises.readFile(filePath, "utf8");
+  return JSON.parse(content);
 }

--- a/cli2/ebadf-guard.ts
+++ b/cli2/ebadf-guard.ts
@@ -1,0 +1,25 @@
+/**
+ * Guard against Node 24 fatal EBADF on FileHandle GC (finos/morphir-elm#1282).
+ *
+ * Since Node 24 (DEP0137 EOL, https://github.com/nodejs/node/pull/58536),
+ * a `fs.FileHandle` that is garbage-collected without an explicit `close()`
+ * throws a fatal uncaughtException with `code === 'EBADF'` and
+ * `syscall === 'close'` (message: "Closing file descriptor X on garbage
+ * collection failed, close") instead of the previous deprecation warning.
+ * The CLI's work has already completed successfully when this fires during
+ * wind-down, so the process dying with exit 1 breaks build systems.
+ *
+ * This guard swallows exactly that error shape and re-throws everything else.
+ * It is idempotent across multiple `import` calls via a global flag.
+ */
+const g = globalThis as unknown as { __morphirEbadfGuardInstalled?: boolean };
+if (!g.__morphirEbadfGuardInstalled) {
+  g.__morphirEbadfGuardInstalled = true;
+  process.on('uncaughtException', (err: unknown) => {
+    const e = err as { code?: string; syscall?: string } | null | undefined;
+    if (e && e.code === 'EBADF' && e.syscall === 'close') {
+      return;
+    }
+    throw err;
+  });
+}

--- a/cli2/ebadf-guard.ts
+++ b/cli2/ebadf-guard.ts
@@ -9,15 +9,25 @@
  * The CLI's work has already completed successfully when this fires during
  * wind-down, so the process dying with exit 1 breaks build systems.
  *
- * This guard swallows exactly that error shape and re-throws everything else.
+ * This guard swallows exactly that GC diagnostic and re-throws everything
+ * else. An ordinary double-close via `fs.close()` callback has the same
+ * `EBADF`/`close` fields but without the GC message, so it must not be
+ * swallowed — it indicates a real resource-handling bug while work is still
+ * in progress.
  * It is idempotent across multiple `import` calls via a global flag.
  */
 const g = globalThis as unknown as { __morphirEbadfGuardInstalled?: boolean };
 if (!g.__morphirEbadfGuardInstalled) {
   g.__morphirEbadfGuardInstalled = true;
   process.on('uncaughtException', (err: unknown) => {
-    const e = err as { code?: string; syscall?: string } | null | undefined;
-    if (e && e.code === 'EBADF' && e.syscall === 'close') {
+    const e = err as { code?: string; syscall?: string; message?: string } | null | undefined;
+    if (
+      e &&
+      e.code === 'EBADF' &&
+      e.syscall === 'close' &&
+      typeof e.message === 'string' &&
+      e.message.includes('garbage collection')
+    ) {
       return;
     }
     throw err;

--- a/cli2/get-uri-wrapper.ts
+++ b/cli2/get-uri-wrapper.ts
@@ -4,15 +4,47 @@ import { z } from "zod";
 
 export async function fetchUriToJson(uri: string | URL) {
   const data = await getUri(uri);
-  const buffer = await toBuffer(data);
-  const jsonString = buffer.toString();
-  return JSON.parse(jsonString);
+  try {
+    const buffer = await toBuffer(data);
+    const jsonString = buffer.toString();
+    return JSON.parse(jsonString);
+  } finally {
+    // Ensure the underlying file descriptor is closed even if parsing throws
+    // or if the stream was not fully consumed. Without this, a fs.ReadStream
+    // from get-uri/file:// can be GC'd with an open fd, which under Node 24
+    // surfaces as a fatal EBADF close-on-GC (finos/morphir-elm#1282).
+    destroyStream(data);
+  }
 }
 
 async function toBuffer(stream: Readable): Promise<Buffer> {
-  const chunks: Buffer[] = [];
-  for await (const chunk of stream) {
-    chunks.push(chunk);
+  try {
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream) {
+      chunks.push(chunk);
+    }
+    return Buffer.concat(chunks as unknown as Uint8Array[]);
+  } finally {
+    destroyStream(stream);
   }
-  return Buffer.concat(chunks as unknown as Uint8Array[]);
+}
+
+function destroyStream(stream: Readable): void {
+  const s = stream as unknown as {
+    destroy?: () => void;
+    close?: () => void;
+    readableEnded?: boolean;
+    destroyed?: boolean;
+  };
+  // Prefer destroy() which properly closes the fd for fs.ReadStream
+  if (s.destroyed || s.readableEnded) return;
+  try {
+    if (typeof s.destroy === "function") {
+      s.destroy();
+    } else if (typeof s.close === "function") {
+      s.close();
+    }
+  } catch {
+    // Ignore destroy errors - fd may already be closed
+  }
 }

--- a/cli2/morphir-dockerize.ts
+++ b/cli2/morphir-dockerize.ts
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 
+// Guard against Node 24 EBADF double-close on GC (finos/morphir-elm#1282)
+import "./ebadf-guard.js";
+
 // NPM Imports
 import { Command } from "commander";
 import { dockerize } from "./cliAPI.js";

--- a/cli2/morphir-generate-test-data.ts
+++ b/cli2/morphir-generate-test-data.ts
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 
+// Guard against Node 24 EBADF double-close on GC (finos/morphir-elm#1282)
+import "./ebadf-guard.js";
+
 // NPM imports
 import { Command } from 'commander'
 import { createRequire } from "module";

--- a/cli2/morphir-init.ts
+++ b/cli2/morphir-init.ts
@@ -1,3 +1,6 @@
+// Guard against Node 24 EBADF double-close on GC (finos/morphir-elm#1282)
+import "./ebadf-guard.js";
+
 import FileSystemModule from 'fs'
 import chalk from 'chalk'
 import path from 'path'

--- a/cli2/morphir-json-schema-gen.ts
+++ b/cli2/morphir-json-schema-gen.ts
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 
+// Guard against Node 24 EBADF double-close on GC (finos/morphir-elm#1282)
+import "./ebadf-guard.js";
+
 // NPM imports
 import { Command } from 'commander';
 import path from 'path';

--- a/cli2/morphir-make.ts
+++ b/cli2/morphir-make.ts
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 
+// Guard against Node 24 EBADF double-close on GC (finos/morphir-elm#1282)
+import "./ebadf-guard.js";
+
 // NPM imports
 import { Command } from 'commander'
 import { make } from './cliAPI.js'

--- a/cli2/morphir-mcp.ts
+++ b/cli2/morphir-mcp.ts
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 
+// Guard against Node 24 EBADF double-close on GC (finos/morphir-elm#1282)
+import "./ebadf-guard.js";
+
 import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";

--- a/cli2/morphir-scala-gen.ts
+++ b/cli2/morphir-scala-gen.ts
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 
+// Guard against Node 24 EBADF double-close on GC (finos/morphir-elm#1282)
+import "./ebadf-guard.js";
+
 //NPM imports
 import * as fs from "fs";
 import path from 'path';

--- a/cli2/morphir-snowpark-gen.ts
+++ b/cli2/morphir-snowpark-gen.ts
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 
+// Guard against Node 24 EBADF double-close on GC (finos/morphir-elm#1282)
+import "./ebadf-guard.js";
+
 // NPM imports
 import * as fs from "fs";
 import path from 'path';

--- a/cli2/morphir-stats.ts
+++ b/cli2/morphir-stats.ts
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 
+// Guard against Node 24 EBADF double-close on GC (finos/morphir-elm#1282)
+import "./ebadf-guard.js";
+
 // NPM imports
 import { Command } from 'commander'
 import * as cli from './cli.js'

--- a/cli2/morphir-test-coverage.ts
+++ b/cli2/morphir-test-coverage.ts
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 
+// Guard against Node 24 EBADF double-close on GC (finos/morphir-elm#1282)
+import "./ebadf-guard.js";
+
 // NPM Imports
 import { Command } from "commander";
 import * as fs from "fs";

--- a/cli2/morphir-typescript-gen.ts
+++ b/cli2/morphir-typescript-gen.ts
@@ -1,5 +1,8 @@
 #!/usr/bin/env node
 
+// Guard against Node 24 EBADF double-close on GC (finos/morphir-elm#1282)
+import "./ebadf-guard.js";
+
 //NPM imports
 import * as fs from "fs";
 import path from 'path';

--- a/cli2/morphir.ts
+++ b/cli2/morphir.ts
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+// Guard against Node 24 EBADF double-close on GC (finos/morphir-elm#1282)
+import "./ebadf-guard.js";
+
 // NPM imports
 import path from "path";
 import { fileURLToPath } from "url";

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   },
   "files": [
     "cli/cli.js",
+    "cli/ebadf-guard.js",
     "cli/morphir-elm.js",
     "cli/morphir-elm-make.js",
     "cli/morphir-elm-gen.js",


### PR DESCRIPTION
Closes #1282

## Summary

Since Node 24 (DEP0137 EOL, nodejs/node#58536), a `fs.FileHandle`/`ReadStream` GC'd without explicit close throws a fatal `uncaughtException` with `EBADF`/`close` (`Closing file descriptor X on garbage collection failed, close`) instead of a deprecation warning. The CLI's work has already completed when this fires during wind-down, so the process exits 1 and breaks downstream builds (e.g. morphir-scala Mill). The crash is probabilistic and host-scoped (fd 22 in reported runs, 5 consecutive failures, also with `-j 1`), consistent with GC timing.

## Fix

**1. Guard as safety net (6b4d3f2d):**
- `cli/ebadf-guard.js` (CJS) + `cli2/ebadf-guard.ts` (ESM) — idempotent `uncaughtException` handler that swallows _only_ `code===EBADF && syscall===close` and re-throws otherwise (same shape as downstream NODE_OPTIONS shim in finos/morphir-scala#965).
- Installed at top of every CLI entry point (`cli/*` and `cli2/*`) and `package.json` `files` updated.

**2. Root cause (9cdefc6a):**
- `cli2/get-uri-wrapper.ts`: ensure every `getUri` `ReadStream` is `destroy()`'d in `finally` (both after `fetchUriToJson` and inside `toBuffer`). Without this, a `fs.ReadStream` from `get-uri/file.js` can be GC'd with an open fd.
- `cli2/dependencies.ts`: for `file://` (`FileUrl`/`LocalFile`) bypass `get-uri` entirely via `fs/promises.readFile` + `fileURLToPath`. This avoids `get-uri/file.js`'s `open`→`fstat`→`createReadStream` path that can leak an fd if `fstat` fails or the stream isn't fully consumed.

The guard remains for any remaining edge case (e.g. transitive deps).

## Testing

- `mise run build:cli2` passes; `morphir make` on `tests-integration/reference-model` (50 files) and local-dep projects passes.
- Guard verified: EBADF close swallowed (exit 0), non-EBADF / EBADF+read still crashes (exit 7).
- Worktree: `/tmp/morphir-elm-fix-1282` on `fix/ebadf-guard-1282`.